### PR TITLE
[feat] RefreshToken 전송시 Header 내의 Cookie 에 감싸도록 구현

### DIFF
--- a/backend/src/main/java/moheng/auth/dto/AccessTokenResponse.java
+++ b/backend/src/main/java/moheng/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,13 @@
+package moheng.auth.dto;
+
+public class AccessTokenResponse {
+
+    private String accessToken;
+
+    private AccessTokenResponse() {
+    }
+
+    public AccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/moheng/auth/presentation/AuthController.java
+++ b/backend/src/main/java/moheng/auth/presentation/AuthController.java
@@ -44,10 +44,11 @@ public class AuthController {
     }
 
     @PostMapping("/extend/login")
-    public ResponseEntity<RenewalAccessTokenResponse> extendLogin(@RequestBody final RenewalAccessTokenRequest renewalAccessTokenRequest) {
+    public ResponseEntity<RenewalAccessTokenResponse> extendLogin(
+            @CookieValue("refresh-token") final String refreshToken) {
         final RenewalAccessTokenResponse renewalAccessTokenResponse =
-                authService.generateRenewalAccessToken(renewalAccessTokenRequest);
-        return ResponseEntity.ok(renewalAccessTokenResponse);
+                authService.generateRenewalAccessToken(new RenewalAccessTokenRequest(refreshToken));
+        return ResponseEntity.status(CREATED).body(renewalAccessTokenResponse);
     }
 
     @DeleteMapping("/logout")

--- a/backend/src/main/java/moheng/auth/presentation/AuthController.java
+++ b/backend/src/main/java/moheng/auth/presentation/AuthController.java
@@ -53,8 +53,8 @@ public class AuthController {
 
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(@Authentication final Accessor accessor,
-                                       @RequestBody final LogoutRequest logoutRequest) {
-        authService.removeRefreshToken(logoutRequest);
+                                       @CookieValue("refresh-token") final String refreshToken) {
+        authService.removeRefreshToken(new LogoutRequest(refreshToken));
         return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## 관련 IssueNumber

#46 

## 체크리스트
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)

## 변경사항

- 기존에 Request/Response Body 를 통해 송수신하던 RefreshToken 을 Header 내의 Cookie 에 감싸서 송수신하도록 구현했습니다.
