### PR TITLE
[feat] 풀리퀘스트의 라벨 마감기한을 DISCORD 웹훅으로 전송하는 기능

### DIFF
--- a/.github/events/pr.json
+++ b/.github/events/pr.json
@@ -1,0 +1,17 @@
+{
+  "action": "labeled",
+  "pull_request": {
+    "number": 59,
+    "title": "[feat] 오늘까지 끝내야 할지도?",
+    "html_url": "https://github.com/kakaotech-25/moheng/pull/59"
+  },
+  "label": {
+    "name": "D-3"
+  },
+  "repository": {
+    "name": "moheng",
+    "owner": {
+      "login": "kakaotech-25"
+    }
+  }
+}

--- a/.github/scripts/pr-deadline/caculate_deadline.sh
+++ b/.github/scripts/pr-deadline/caculate_deadline.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# 입력으로 받은 날짜 수
+days_to_add="${1}"
+
+# 현재 날짜와 시간을 UTC로 가져옴
+current_time=$(date -u +"%Y-%m-%d %H:%M:%S")
+echo "Current time (UTC): $current_time"
+
+# 마감 날짜 계산 (UTC)
+if [ "$days_to_add" -eq 0 ]; then
+    # days_to_add 가 0인 경우 오늘 자정
+    deadline_utc=$(date -u -d "tomorrow" +"%Y-%m-%d 00:00:00")
+else
+    # days_to_add 가 0이 아닌 경우 마감 날짜 계산 (UTC)
+    deadline_utc=$(date -u -d "$days_to_add day" +"%Y-%m-%d %H:%M:%S")
+fi
+
+# 마감 날짜를 한국 표준시(KST)로 변환하여 출력 (오전/오후 포함)
+deadline_kst=$(TZ=Asia/Seoul date -d "$deadline_utc" +"%m월 %d일 %p %I시 %M분")
+echo "Deadline (KST): $deadline_kst"
+
+# 결과 출력 & deadline 변수 재정의
+echo "deadline=$deadline_kst" >> $GITHUB_OUTPUT

--- a/.github/scripts/pr-deadline/extract_deadline.sh
+++ b/.github/scripts/pr-deadline/extract_deadline.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+label_name="${1}"
+
+if [[ "$label_name" == D-* ]]; then
+  deadline=${label_name:2}
+  echo "마감 라벨을 설정했습니다. 마감일: $deadline"
+  echo "deadline=$deadline" >> $GITHUB_OUTPUT
+else
+  echo "마감 라벨을 설정하지 않았습니다."
+  exit 1
+fi

--- a/.github/scripts/pr-deadline/send_discord_notification.sh
+++ b/.github/scripts/pr-deadline/send_discord_notification.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# 매개변수
+webhook_url="${1}"
+deadline="${2}"
+
+# 메시지 생성
+message="마감기간 : ${deadline}"
+
+echo -e "${message}"
+
+# Discord 웹훅으로 메시지 전송
+
+curl -H "Content-Type: application/json" \
+     -d "{\"content\": \"${message}\"}" \
+     "${webhook_url}"

--- a/.github/workflows/pr-deadline-notifier.yml
+++ b/.github/workflows/pr-deadline-notifier.yml
@@ -1,0 +1,31 @@
+name: PR Deadline Notifier
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  calculate-deadline:
+    runs-on: ubuntu-latest
+    env:
+      SCRIPTS_DIR: .github/scripts/pr-deadline
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }} # Add this line to define the DISCORD_WEBHOOK_URL environment variable
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set execute permissions for scripts
+        run: chmod +x ${{ env.SCRIPTS_DIR }}/*.sh
+
+      - name: Extract Deadline from Label
+        id: extract_deadline
+        run: ${{ env.SCRIPTS_DIR }}/extract_deadline.sh "${{ github.event.label.name }}"
+
+      - name: Calculate Time Remaining
+        id: calculate_deadline
+        run: ${{ env.SCRIPTS_DIR }}/caculate_deadline.sh "${{ steps.extract_deadline.outputs.deadline }}"
+
+      - name: Send Discord Notification
+        if: always()
+        run: ${{ env.SCRIPTS_DIR }}/send_discord_notification.sh "${{ env.DISCORD_WEBHOOK_URL }}" "${{ steps.calculate_deadline.outputs.deadline }}" # Update this line to use the DISCORD_WEBHOOK_URL environment variable

--- a/.github/workflows/pr-deadline-notifier.yml
+++ b/.github/workflows/pr-deadline-notifier.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SCRIPTS_DIR: .github/scripts/pr-deadline
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }} # Add this line to define the DISCORD_WEBHOOK_URL environment variable
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }} # Add this line to define the DISCORD_WEBHOOK_URL environment variable
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
## 관련 IssueNumber

> #62 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 마감라벨의 D-DAY을 현재 시간에 더하여 마감기한을 디스코드 채널에 전송하는 기능
- D-0의 경우 당일의 자정시간을 기준으로 설정
