### PR TITLE
[fix] 빈 라벨일 때 알림을 보내지 않도록 설정

### DIFF
--- a/.github/workflows/pr-deadline-notifier.yml
+++ b/.github/workflows/pr-deadline-notifier.yml
@@ -27,5 +27,5 @@ jobs:
         run: ${{ env.SCRIPTS_DIR }}/caculate_time.sh "${{ steps.extract_deadline.outputs.deadline }}"
 
       - name: Send Discord Notification
-        if: always()
+        if: ${{ success() }}
         run: ${{ env.SCRIPTS_DIR }}/send_discord_notification.sh "${{ env.DISCORD_WEBHOOK_URL }}" "${{ steps.caculate_time.outputs.deadline }}"


### PR DESCRIPTION
## 관련 IssueNumber
#74 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- discord 알림을 보내는 조건을 라벨 추출이 성공했을 때 동작하도록 변경
