### PR TITLE
[fix] D-day라벨이 아니어도 실패하지 않도록 수정

### DIFF
--- a/.github/scripts/pr-deadline/extract_deadline.sh
+++ b/.github/scripts/pr-deadline/extract_deadline.sh
@@ -7,5 +7,4 @@ if [[ "$label_name" == D-* ]]; then
   echo "deadline=$deadline" >> $GITHUB_OUTPUT
 else
   echo "마감 라벨을 설정하지 않았습니다."
-  exit 1
 fi

--- a/.github/workflows/pr-deadline-notifier.yml
+++ b/.github/workflows/pr-deadline-notifier.yml
@@ -24,8 +24,9 @@ jobs:
 
       - name: Calculate Time Remaining
         id: caculate_time
+        if: ${{ steps.extract_deadline.outputs.deadline }}
         run: ${{ env.SCRIPTS_DIR }}/caculate_time.sh "${{ steps.extract_deadline.outputs.deadline }}"
 
       - name: Send Discord Notification
-        if: ${{ success() }}
+        if: ${{ steps.caculate_time.outputs.deadline }}
         run: ${{ env.SCRIPTS_DIR }}/send_discord_notification.sh "${{ env.DISCORD_WEBHOOK_URL }}" "${{ steps.caculate_time.outputs.deadline }}"


### PR DESCRIPTION
## 관련 IssueNumber

#74 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- D-day라벨이 아닌경우 exit 1로 종료하던 코드를 제거했습니다.
- action의 모든 job들이 if문으로 이전 파이프라인의 결과를 참조한 뒤 실행하도록 변경했습니다. 
