### PR TITLE
[feat] 회원가입 절차를 마치지 않은 최초 가입 회원과 일반회원을 구분한 ArgumentResolver 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -106,7 +106,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = "LINE"
 				value = "COVEREDRATIO"
-				// minimum = 0.70
+				minimum = 0.70
 			}
 
 			excludes = [

--- a/backend/src/main/java/moheng/auth/domain/oauth/KakaoOAuthClient.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/KakaoOAuthClient.java
@@ -43,13 +43,11 @@ public class KakaoOAuthClient implements OAuthClient {
     }
 
     @Override
-    @Generated
     public boolean isSame(String providerName) {
         return PROVIDER_NAME.equals(providerName);
     }
 
     @Override
-    @Generated
     public OAuthMember getOAuthMember(final String code) {
         final String accessToken = requestKakaoAccessToken(code);
         final HttpHeaders httpHeaders = new HttpHeaders();
@@ -73,7 +71,6 @@ public class KakaoOAuthClient implements OAuthClient {
         throw new InvalidOAuthServiceException("카카오 OAuth 소셜 로그인 서버에 예기치 못한 오류가 발생했습니다.");
     }
 
-    @Generated
     private String requestKakaoAccessToken(String code) {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         final HttpHeaders httpHeaders = new HttpHeaders();

--- a/backend/src/main/java/moheng/auth/domain/oauth/KakaoUriProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/KakaoUriProvider.java
@@ -23,7 +23,7 @@ public class KakaoUriProvider implements OAuthUriProvider {
     public String generateUri() {
         return authorizationUri + "?"
                 + "client_id=" + clientId
-//                + "&redirect_uri=" + redirectUri
+                + "&redirect_uri=" + redirectUri
                 + "&response_type=" + response_type;
     }
 

--- a/backend/src/main/java/moheng/auth/domain/oauth/OAuthClientProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/OAuthClientProvider.java
@@ -19,7 +19,6 @@ public class OAuthClientProvider implements OAuthProvider {
     }
 
     @Override
-    @Generated
     public OAuthClient getOauthClient(final String provider) {
         return oAuthClients.stream()
                 .filter(oAuthClient -> oAuthClient.isSame(provider))
@@ -28,7 +27,6 @@ public class OAuthClientProvider implements OAuthProvider {
     }
 
     @Override
-    @Generated
     public OAuthUriProvider getOAuthUriProvider(final String provider) {
         return oAuthUriProviders.stream()
                 .filter(oAuthUriProvider -> oAuthUriProvider.isSame(provider))
@@ -37,7 +35,6 @@ public class OAuthClientProvider implements OAuthProvider {
     }
 
     @Override
-    @Generated
     public SocialType getSocialType(final String provider) {
         return SocialType.findByName(provider);
     }

--- a/backend/src/main/java/moheng/auth/exception/InvalidInitAuthorityException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidInitAuthorityException.java
@@ -1,0 +1,7 @@
+package moheng.auth.exception;
+
+public class InvalidInitAuthorityException extends RuntimeException {
+    public InvalidInitAuthorityException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/moheng/auth/exception/InvalidRegularAuthorityException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidRegularAuthorityException.java
@@ -1,0 +1,7 @@
+package moheng.auth.exception;
+
+public class InvalidRegularAuthorityException extends RuntimeException {
+    public InvalidRegularAuthorityException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/moheng/auth/presentation/AuthController.java
+++ b/backend/src/main/java/moheng/auth/presentation/AuthController.java
@@ -58,9 +58,4 @@ public class AuthController {
         authService.removeRefreshToken(new LogoutRequest(refreshToken));
         return ResponseEntity.noContent().build();
     }
-
-    @GetMapping("/validate/token")
-    public ResponseEntity<Void> validateToken(@Authentication final Accessor accessor) {
-        return ResponseEntity.ok().build();
-    }
 }

--- a/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationArgumentResolver.java
+++ b/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationArgumentResolver.java
@@ -32,7 +32,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        System.out.println(parameter.hasParameterAnnotation(Authentication.class));
         return parameter.hasParameterAnnotation(Authentication.class);
     }
 
@@ -51,13 +50,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
         final String accessToken = authenticationBearerExtractor.extract(request);
         jwtTokenProvider.validateToken(accessToken);
         final Long id = jwtTokenProvider.getMemberId(accessToken);
-
-        final Member regularMember = memberRepository.findById(id)
-                .orElseThrow(() -> new NoExistMemberException("존재하지 않는 유저입니다."));
-
-        if(!regularMember.getAuthority().equals(Authority.REGULAR_MEMBER)) {
-            throw new InvalidRegularAuthorityException("정규 회원 기능에 대한 접근 권한이 없습니다.");
-        }
         return new Accessor(id);
     }
 }

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthentication.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthentication.java
@@ -1,0 +1,11 @@
+package moheng.auth.presentation.initauthentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InitAuthentication {
+}

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
@@ -34,7 +34,6 @@ public class InitAuthenticationArgumentResolver implements HandlerMethodArgument
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        System.out.println(parameter.hasParameterAnnotation(InitAuthentication.class));
         return parameter.hasParameterAnnotation(InitAuthentication.class);
     }
 
@@ -54,12 +53,13 @@ public class InitAuthenticationArgumentResolver implements HandlerMethodArgument
         jwtTokenProvider.validateToken(accessToken);
         final Long id = jwtTokenProvider.getMemberId(accessToken);
 
-        final Member initMember = memberRepository.findById(id)
-                .orElseThrow(() -> new NoExistMemberException("존재하지 않는 유저입니다."));
+        Member member = memberRepository.findById(id)
+                .orElseThrow(NoExistMemberException::new);
 
-        if(!initMember.getAuthority().equals(Authority.INIT_MEMBER)) {
+        if(!member.getAuthority().equals(Authority.INIT_MEMBER)) {
             throw new InvalidInitAuthorityException("초기 회원가입 기능에 대한 접근 권한이 없습니다.");
         }
+
         return new Accessor(id);
     }
 }

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
@@ -1,11 +1,16 @@
 package moheng.auth.presentation.initauthentication;
 
 import jakarta.servlet.http.HttpServletRequest;
+import moheng.auth.domain.oauth.Authority;
 import moheng.auth.domain.token.JwtTokenProvider;
 import moheng.auth.dto.Accessor;
 import moheng.auth.exception.BadRequestException;
+import moheng.auth.exception.InvalidInitAuthorityException;
 import moheng.auth.presentation.authentication.Authentication;
 import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
+import moheng.member.domain.Member;
+import moheng.member.domain.repository.MemberRepository;
+import moheng.member.exception.NoExistMemberException;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -17,10 +22,14 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class InitAuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationBearerExtractor authenticationBearerExtractor;
+    private final MemberRepository memberRepository;
 
-    public InitAuthenticationArgumentResolver(final JwtTokenProvider jwtTokenProvider, final AuthenticationBearerExtractor authenticationBearerExtractor) {
+    public InitAuthenticationArgumentResolver(final JwtTokenProvider jwtTokenProvider,
+                                              final AuthenticationBearerExtractor authenticationBearerExtractor,
+                                              final MemberRepository memberRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.authenticationBearerExtractor = authenticationBearerExtractor;
+        this.memberRepository = memberRepository;
     }
 
     @Override
@@ -45,6 +54,12 @@ public class InitAuthenticationArgumentResolver implements HandlerMethodArgument
         jwtTokenProvider.validateToken(accessToken);
         final Long id = jwtTokenProvider.getMemberId(accessToken);
 
+        final Member initMember = memberRepository.findById(id)
+                .orElseThrow(() -> new NoExistMemberException("존재하지 않는 유저입니다."));
+
+        if(!initMember.getAuthority().equals(Authority.INIT_MEMBER)) {
+            throw new InvalidInitAuthorityException("초기 회원가입 기능에 대한 접근 권한이 없습니다.");
+        }
         return new Accessor(id);
     }
 }

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
@@ -25,8 +25,8 @@ public class InitAuthenticationArgumentResolver implements HandlerMethodArgument
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        System.out.println(parameter.hasParameterAnnotation(Authentication.class));
-        return parameter.hasParameterAnnotation(Authentication.class);
+        System.out.println(parameter.hasParameterAnnotation(InitAuthentication.class));
+        return parameter.hasParameterAnnotation(InitAuthentication.class);
     }
 
     @Override

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationWebConfig.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationWebConfig.java
@@ -1,0 +1,22 @@
+package moheng.auth.presentation.initauthentication;
+
+import moheng.auth.presentation.authentication.AuthenticationArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class InitAuthenticationWebConfig implements WebMvcConfigurer {
+    private final InitAuthenticationArgumentResolver initAuthenticationArgumentResolver;
+
+    public InitAuthenticationWebConfig(final InitAuthenticationArgumentResolver initAuthenticationArgumentResolver) {
+        this.initAuthenticationArgumentResolver = initAuthenticationArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(initAuthenticationArgumentResolver);
+    }
+}

--- a/backend/src/main/java/moheng/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/moheng/global/error/ControllerAdvice.java
@@ -30,6 +30,7 @@ public class ControllerAdvice {
             InvalidGenderFormatException.class,
             InvalidNicknameFormatException.class,
             NoExistMemberTokenException.class,
+            NoExistMemberException.class,
             NoExistSocialTypeException.class,
             EmptyLiveInformationException.class,
             ShortContentidsSizeException.class

--- a/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
@@ -6,9 +6,11 @@ import moheng.liveinformation.dto.FindAllLiveInformationResponse;
 import moheng.liveinformation.dto.LiveInformationCreateRequest;
 import moheng.liveinformation.exception.NoExistLiveInformationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Transactional(readOnly = true)
 @Service
 public class LiveInformationService {
     private final LiveInformationRepository liveInformationRepository;
@@ -21,11 +23,13 @@ public class LiveInformationService {
         return new FindAllLiveInformationResponse(liveInformationRepository.findAll());
     }
 
+    @Transactional
     public void createLiveInformation(LiveInformationCreateRequest request) {
         final LiveInformation liveInformation = new LiveInformation(request.getName());
         liveInformationRepository.save(liveInformation);
     }
 
+    @Transactional
     public LiveInformation save(LiveInformation liveInformation) {
         return liveInformationRepository.save(liveInformation);
     }

--- a/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
@@ -34,6 +34,4 @@ public class LiveInformationService {
         return liveInformationRepository.findByName(liveTypeName)
                 .orElseThrow(() -> new NoExistLiveInformationException("존재하지 않는 생활정보입니다."));
     }
-
-    public
 }

--- a/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
@@ -34,4 +34,6 @@ public class LiveInformationService {
         return liveInformationRepository.findByName(liveTypeName)
                 .orElseThrow(() -> new NoExistLiveInformationException("존재하지 않는 생활정보입니다."));
     }
+
+    public
 }

--- a/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
@@ -63,7 +63,7 @@ public class MemberLiveInformationService {
         return new FindMemberLiveInformationResponses(findMemberSelectedLiveInfos(allLiveInformation, memberLiveInfoIds));
     }
 
-    private List<Long> findMemberLiveInfoIds(final Long memberId) {
+    public List<Long> findMemberLiveInfoIds(final Long memberId) {
         return memberLiveInformationRepository.findByMemberId(memberId)
                 .stream().map(memberLiveInfo -> memberLiveInfo.getLiveInformation().getId())
                 .collect(Collectors.toList());

--- a/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
@@ -42,9 +42,9 @@ public class MemberLiveInformationService {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoExistMemberException("존재하지 않는 회원입니다."));
 
-        List<LiveInformation> liveInformations = liveInformationRepository.findAllById(request.getContentIds());
+        List<LiveInformation> liveInformations = liveInformationRepository.findAllById(request.getLiveInfoIds());
         memberLiveInformationRepository.deleteByMemberId(memberId);
-       saveMemberLiveInformation(liveInformations, member);
+        saveMemberLiveInformation(liveInformations, member);
     }
 
     private void saveMemberLiveInformation(List<LiveInformation> liveInformations, Member member) {

--- a/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
@@ -1,6 +1,9 @@
-package moheng.liveinformation.domain;
+package moheng.liveinformation.application;
 
-import moheng.liveinformation.dto.FindAllLiveInformationResponse;
+import moheng.liveinformation.domain.LiveInformation;
+import moheng.liveinformation.domain.LiveInformationRepository;
+import moheng.liveinformation.domain.MemberLiveInformation;
+import moheng.liveinformation.domain.MemberLiveInformationRepository;
 import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
 import moheng.liveinformation.dto.LiveInfoResponse;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
@@ -7,10 +7,12 @@ import moheng.liveinformation.domain.MemberLiveInformationRepository;
 import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
 import moheng.liveinformation.dto.LiveInfoResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Transactional(readOnly = true)
 @Service
 public class MemberLiveInformationService {
     private final MemberLiveInformationRepository memberLiveInformationRepository;

--- a/backend/src/main/java/moheng/liveinformation/domain/LiveInformation.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/LiveInformation.java
@@ -2,10 +2,14 @@ package moheng.liveinformation.domain;
 
 import jakarta.persistence.*;
 import moheng.global.entity.BaseEntity;
+import moheng.liveinformation.exception.LiveInfoNameException;
 
 @Table(name = "live_information")
 @Entity
 public class LiveInformation extends BaseEntity {
+    private static final int MIN_NAME_LENGTH = 1;
+    private static final int MAX_NAME_LENGTH = 100;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -18,12 +22,20 @@ public class LiveInformation extends BaseEntity {
     }
 
     public LiveInformation(Long id, String name) {
+        validateName(name);
         this.id = id;
         this.name = name;
     }
 
     public LiveInformation(String name) {
+        validateName(name);
         this.name = name;
+    }
+
+    private void validateName(String name) {
+        if(name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
+            throw new LiveInfoNameException("생활정보 이름의 길이는 최소 1자 이상, 최대 100자 이하만 허용됩니다.");
+        }
     }
 
     public Long getId() {

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformation.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformation.java
@@ -1,6 +1,7 @@
 package moheng.liveinformation.domain;
 
 import jakarta.persistence.*;
+import moheng.global.annotation.Generated;
 import moheng.member.domain.Member;
 
 @Table(name = "member_live_information")
@@ -27,6 +28,7 @@ public class MemberLiveInformation {
         this.member = member;
     }
 
+    @Generated
     public Long getId() {
         return id;
     }
@@ -35,6 +37,7 @@ public class MemberLiveInformation {
         return liveInformation;
     }
 
+    @Generated
     public Member getMember() {
         return member;
     }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformation.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformation.java
@@ -26,4 +26,16 @@ public class MemberLiveInformation {
         this.liveInformation = liveInformation;
         this.member = member;
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LiveInformation getLiveInformation() {
+        return liveInformation;
+    }
+
+    public Member getMember() {
+        return member;
+    }
 }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface MemberLiveInformationRepository extends JpaRepository<MemberLiveInformation, Long> {
     List<MemberLiveInformation> findByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
@@ -2,5 +2,8 @@ package moheng.liveinformation.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberLiveInformationRepository extends JpaRepository<MemberLiveInformation, Long> {
+    List<MemberLiveInformation> findByMemberId(Long memberId);
 }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
@@ -1,10 +1,13 @@
 package moheng.liveinformation.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface MemberLiveInformationRepository extends JpaRepository<MemberLiveInformation, Long> {
     List<MemberLiveInformation> findByMemberId(Long memberId);
+
+    @Transactional
     void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationService.java
@@ -1,18 +1,47 @@
 package moheng.liveinformation.domain;
 
+import moheng.liveinformation.dto.FindAllLiveInformationResponse;
+import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import moheng.liveinformation.dto.LiveInfoResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MemberLiveInformationService {
     private final MemberLiveInformationRepository memberLiveInformationRepository;
+    private final LiveInformationRepository liveInformationRepository;
 
-    public MemberLiveInformationService(MemberLiveInformationRepository memberLiveInformationRepository) {
+    public MemberLiveInformationService(
+            final MemberLiveInformationRepository memberLiveInformationRepository,
+            final LiveInformationRepository liveInformationRepository) {
         this.memberLiveInformationRepository = memberLiveInformationRepository;
+        this.liveInformationRepository = liveInformationRepository;
     }
 
     public void saveAll(List<MemberLiveInformation> memberLiveInformations) {
         memberLiveInformationRepository.saveAll(memberLiveInformations);
+    }
+
+    public FindMemberLiveInformationResponses findMemberSelectedLiveInformation(Long memberId) {
+        final List<LiveInformation> allLiveInformation = liveInformationRepository.findAll();
+        final List<Long> memberLiveInfoIds = findMemberLiveInfoIds(memberId);
+        return new FindMemberLiveInformationResponses(findMemberSelectedLiveInfos(allLiveInformation, memberLiveInfoIds));
+    }
+
+    private List<Long> findMemberLiveInfoIds(final Long memberId) {
+        return memberLiveInformationRepository.findByMemberId(memberId)
+                .stream().map(memberLiveInfo -> memberLiveInfo.getLiveInformation().getId())
+                .collect(Collectors.toList());
+    }
+
+    private List<LiveInfoResponse> findMemberSelectedLiveInfos(final List<LiveInformation> allLiveInformation, List<Long> selectedLiveInfoIds) {
+        return allLiveInformation.stream()
+                .map(liveInfo -> new LiveInfoResponse(
+                        liveInfo.getId(),
+                        liveInfo.getName(),
+                        selectedLiveInfoIds.contains(liveInfo.getId())))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/dto/FindMemberLiveInformationResponses.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/FindMemberLiveInformationResponses.java
@@ -1,0 +1,18 @@
+package moheng.liveinformation.dto;
+
+import java.util.List;
+
+public class FindMemberLiveInformationResponses {
+    private List<LiveInfoResponse> liveInfoResponses;
+
+    private FindMemberLiveInformationResponses() {
+    }
+
+    public FindMemberLiveInformationResponses(List<LiveInfoResponse> liveInfoResponses) {
+        this.liveInfoResponses = liveInfoResponses;
+    }
+
+    public List<LiveInfoResponse> getLiveInfoResponses() {
+        return liveInfoResponses;
+    }
+}

--- a/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
@@ -1,0 +1,28 @@
+package moheng.liveinformation.dto;
+
+public class LiveInfoResponse {
+    private Long liveInfoId;
+    private String name;
+    private boolean isContain;
+
+    private LiveInfoResponse() {
+    }
+
+    public LiveInfoResponse(Long liveInfoId, String name, boolean isContain) {
+        this.liveInfoId = liveInfoId;
+        this.name = name;
+        this.isContain = isContain;
+    }
+
+    public Long getLiveInfoId() {
+        return liveInfoId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isContain() {
+        return isContain;
+    }
+}

--- a/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
@@ -3,15 +3,15 @@ package moheng.liveinformation.dto;
 public class LiveInfoResponse {
     private Long liveInfoId;
     private String name;
-    private boolean isContain;
+    private boolean contain;
 
     private LiveInfoResponse() {
     }
 
-    public LiveInfoResponse(Long liveInfoId, String name, boolean isContain) {
+    public LiveInfoResponse(Long liveInfoId, String name, boolean contain) {
         this.liveInfoId = liveInfoId;
         this.name = name;
-        this.isContain = isContain;
+        this.contain = contain;
     }
 
     public Long getLiveInfoId() {
@@ -22,7 +22,7 @@ public class LiveInfoResponse {
         return name;
     }
 
-    public boolean isContain() {
-        return isContain;
+    public boolean getContain() {
+        return contain;
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/dto/MemberLiveInfo.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/MemberLiveInfo.java
@@ -1,0 +1,4 @@
+package moheng.liveinformation.dto;
+
+public class MemberLiveInfo {
+}

--- a/backend/src/main/java/moheng/liveinformation/dto/UpdateMemberLiveInformationRequest.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/UpdateMemberLiveInformationRequest.java
@@ -1,0 +1,18 @@
+package moheng.liveinformation.dto;
+
+import java.util.List;
+
+public class UpdateMemberLiveInformationRequest {
+    private List<Long> contentIds;
+
+    private UpdateMemberLiveInformationRequest() {
+    }
+
+    public UpdateMemberLiveInformationRequest(final List<Long> contentIds) {
+        this.contentIds = contentIds;
+    }
+
+    public List<Long> getContentIds() {
+        return contentIds;
+    }
+}

--- a/backend/src/main/java/moheng/liveinformation/dto/UpdateMemberLiveInformationRequest.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/UpdateMemberLiveInformationRequest.java
@@ -3,16 +3,16 @@ package moheng.liveinformation.dto;
 import java.util.List;
 
 public class UpdateMemberLiveInformationRequest {
-    private List<Long> contentIds;
+    private List<Long> liveInfoIds;
 
     private UpdateMemberLiveInformationRequest() {
     }
 
-    public UpdateMemberLiveInformationRequest(final List<Long> contentIds) {
-        this.contentIds = contentIds;
+    public UpdateMemberLiveInformationRequest(final List<Long> liveInfoIds) {
+        this.liveInfoIds = liveInfoIds;
     }
 
-    public List<Long> getContentIds() {
-        return contentIds;
+    public List<Long> getLiveInfoIds() {
+        return liveInfoIds;
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/exception/LiveInfoNameException.java
+++ b/backend/src/main/java/moheng/liveinformation/exception/LiveInfoNameException.java
@@ -1,0 +1,8 @@
+package moheng.liveinformation.exception;
+
+public class LiveInfoNameException extends RuntimeException {
+    public LiveInfoNameException(String message) {
+        super(message);
+    }
+}
+

--- a/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
@@ -1,8 +1,12 @@
 package moheng.liveinformation.presentation;
 
+import moheng.auth.dto.Accessor;
+import moheng.auth.presentation.authentication.Authentication;
 import moheng.liveinformation.application.LiveInformationService;
+import moheng.liveinformation.application.MemberLiveInformationService;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.dto.FindAllLiveInformationResponse;
+import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
 import moheng.liveinformation.dto.LiveInformationCreateRequest;
 import moheng.liveinformation.dto.LiveInformationResponse;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +18,15 @@ import java.util.List;
 @RestController
 public class LiveInformationController {
     private final LiveInformationService liveInformationService;
+    private final MemberLiveInformationService memberLiveInformationService;
 
-    public LiveInformationController(final LiveInformationService liveInformationService) {
+    public LiveInformationController(final LiveInformationService liveInformationService,
+                                     final MemberLiveInformationService memberLiveInformationService) {
         this.liveInformationService = liveInformationService;
+        this.memberLiveInformationService = memberLiveInformationService;
     }
 
-    @GetMapping
+    @GetMapping("/all")
     public ResponseEntity<FindAllLiveInformationResponse> findAllLiveInformation() {
         return ResponseEntity.ok(liveInformationService.findAllLiveInformation());
     }
@@ -28,5 +35,10 @@ public class LiveInformationController {
     public ResponseEntity<Void> createLiveInformation(final @RequestBody LiveInformationCreateRequest request) {
         liveInformationService.createLiveInformation(request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/member")
+    public ResponseEntity<FindMemberLiveInformationResponses> findAllLiveInformationByUser(@Authentication Accessor accessor) {
+        return ResponseEntity.ok(memberLiveInformationService.findMemberSelectedLiveInformation(accessor.getId()));
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
@@ -36,9 +36,4 @@ public class LiveInformationController {
         liveInformationService.createLiveInformation(request);
         return ResponseEntity.noContent().build();
     }
-
-    @GetMapping("/member")
-    public ResponseEntity<FindMemberLiveInformationResponses> findAllLiveInformationByUser(@Authentication Accessor accessor) {
-        return ResponseEntity.ok(memberLiveInformationService.findMemberSelectedLiveInformation(accessor.getId()));
-    }
 }

--- a/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
@@ -24,7 +24,7 @@ public class MemberLiveInformationController {
 
     @PutMapping
     public ResponseEntity<FindMemberLiveInformationResponses> updateMemberLiveInformation(@Authentication final Accessor accessor,
-                                                                                          final UpdateMemberLiveInformationRequest request) {
+                                                                                          @RequestBody final UpdateMemberLiveInformationRequest request) {
         memberLiveInformationService.updateMemberLiveInformation(accessor.getId(), request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
@@ -4,11 +4,9 @@ import moheng.auth.dto.Accessor;
 import moheng.auth.presentation.authentication.Authentication;
 import moheng.liveinformation.application.MemberLiveInformationService;
 import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/live/info/member")
 @RestController
@@ -20,7 +18,14 @@ public class MemberLiveInformationController {
     }
 
     @GetMapping
-    public ResponseEntity<FindMemberLiveInformationResponses> findAllLiveInformationByUser(@Authentication Accessor accessor) {
+    public ResponseEntity<FindMemberLiveInformationResponses> findAllLiveInformationByMember(@Authentication final Accessor accessor) {
         return ResponseEntity.ok(memberLiveInformationService.findMemberSelectedLiveInformation(accessor.getId()));
+    }
+
+    @PutMapping
+    public ResponseEntity<FindMemberLiveInformationResponses> updateMemberLiveInformation(@Authentication final Accessor accessor,
+                                                                                          final UpdateMemberLiveInformationRequest request) {
+        memberLiveInformationService.updateMemberLiveInformation(accessor.getId(), request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
@@ -1,0 +1,26 @@
+package moheng.liveinformation.presentation;
+
+import moheng.auth.dto.Accessor;
+import moheng.auth.presentation.authentication.Authentication;
+import moheng.liveinformation.application.MemberLiveInformationService;
+import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/live/info/member")
+@RestController
+public class MemberLiveInformationController {
+    private final MemberLiveInformationService memberLiveInformationService;
+
+    public MemberLiveInformationController(MemberLiveInformationService memberLiveInformationService) {
+        this.memberLiveInformationService = memberLiveInformationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<FindMemberLiveInformationResponses> findAllLiveInformationByUser(@Authentication Accessor accessor) {
+        return ResponseEntity.ok(memberLiveInformationService.findMemberSelectedLiveInformation(accessor.getId()));
+    }
+}

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -84,7 +84,8 @@ public class MemberService {
                 member.getId(),
                 request.getNickname(),
                 request.getBirthday(),
-                request.getGenderType()
+                request.getGenderType(),
+                request.getProfileImageUrl()
         );
         memberRepository.save(updateProfileMember);
     }
@@ -152,7 +153,8 @@ public class MemberService {
                 memberId,
                 request.getNickname(),
                 request.getBirthday(),
-                request.getGenderType()
+                request.getGenderType(),
+                request.getProfileImageUrl()
         );
         memberRepository.save(updateMember);
     }

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -168,6 +168,4 @@ public class MemberService {
     private boolean isAlreadyExistNickname(final String nickname) {
         return memberRepository.existsByNickName(nickname);
     }
-
-
 }

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -4,7 +4,7 @@ import moheng.auth.domain.oauth.Authority;
 import moheng.liveinformation.application.LiveInformationService;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.domain.MemberLiveInformation;
-import moheng.liveinformation.domain.MemberLiveInformationService;
+import moheng.liveinformation.application.MemberLiveInformationService;
 import moheng.liveinformation.exception.EmptyLiveInformationException;
 import moheng.member.domain.Member;
 import moheng.member.domain.repository.MemberRepository;
@@ -19,7 +19,6 @@ import moheng.member.exception.ShortContentidsSizeException;
 import moheng.recommendtrip.application.RecommendTripService;
 import moheng.trip.application.TripService;
 import moheng.trip.domain.Trip;
-import moheng.trip.exception.InvalidTripDescriptionException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -152,8 +152,7 @@ public class MemberService {
                 memberId,
                 request.getNickname(),
                 request.getBirthday(),
-                request.getGenderType(),
-                request.getProfileImageUrl()
+                request.getGenderType()
         );
         memberRepository.save(updateMember);
     }

--- a/backend/src/main/java/moheng/member/domain/Member.java
+++ b/backend/src/main/java/moheng/member/domain/Member.java
@@ -2,6 +2,7 @@ package moheng.member.domain;
 
 import jakarta.persistence.*;
 import moheng.auth.domain.oauth.Authority;
+import moheng.global.annotation.Generated;
 import moheng.global.entity.BaseEntity;
 import moheng.member.exception.*;
 
@@ -145,10 +146,6 @@ public class Member extends BaseEntity {
 
     public LocalDate getBirthday() {
         return birthday;
-    }
-
-    public String getEmail() {
-        return email;
     }
 
     public Authority getAuthority() {

--- a/backend/src/main/java/moheng/member/domain/Member.java
+++ b/backend/src/main/java/moheng/member/domain/Member.java
@@ -56,7 +56,7 @@ public class Member extends BaseEntity {
         this.authority = Authority.INIT_MEMBER;
     }
 
-    public Member(final long id, final String nickName, final LocalDate birthday, final GenderType genderType) {
+    public Member(final long id, final String nickName, final LocalDate birthday, final GenderType genderType, final String profileImageUrl) {
         this.id = id;
         this.nickName = nickName;
         this.birthday = birthday;

--- a/backend/src/main/java/moheng/member/domain/Member.java
+++ b/backend/src/main/java/moheng/member/domain/Member.java
@@ -61,19 +61,13 @@ public class Member extends BaseEntity {
         this.nickName = nickName;
         this.birthday = birthday;
         this.genderType = genderType;
-    }
-
-    public Member(final long id, final String nickName, final LocalDate birthday, final GenderType genderType, final String profileImageUrl) {
-        this.id = id;
-        this.nickName = nickName;
-        this.birthday = birthday;
-        this.genderType = genderType;
         this.profileImageUrl = profileImageUrl;
+        this.authority = Authority.REGULAR_MEMBER;
     }
 
     public Member(final Long id, final String email, final String nickName,
-                  final String profileImageUrl, final SocialType socialType,
-                  final LocalDate birthday, final GenderType genderType) {
+                 final String profileImageUrl, final SocialType socialType,
+                 final LocalDate birthday, final GenderType genderType) {
         validateNickName(nickName);
         validateGenderType(genderType);
         validateBirthday(birthday);
@@ -86,6 +80,7 @@ public class Member extends BaseEntity {
         this.socialType = socialType;
         this.birthday = birthday;
         this.genderType = genderType;
+        this.authority = Authority.REGULAR_MEMBER;
     }
 
     public void changePrivilege(Authority authority) {

--- a/backend/src/main/java/moheng/member/dto/response/MemberResponse.java
+++ b/backend/src/main/java/moheng/member/dto/response/MemberResponse.java
@@ -10,14 +10,14 @@ public class MemberResponse {
     private final String profileImageUrl;
     private final String nickname;
     private final LocalDate birthday;
-    private final GenderType gender;
+    private final GenderType genderType;
 
-    public MemberResponse(final Long id, final String profileImageUrl, final String nickname, final LocalDate birthday, final GenderType gender) {
+    public MemberResponse(final Long id, final String profileImageUrl, final String nickname, final LocalDate birthday, final GenderType genderType) {
         this.id = id;
         this.profileImageUrl = profileImageUrl;
         this.nickname = nickname;
         this.birthday = birthday;
-        this.gender = gender;
+        this.genderType = genderType;
     }
 
     public MemberResponse(final Member member) {
@@ -25,7 +25,7 @@ public class MemberResponse {
         this.profileImageUrl = member.getProfileImageUrl();
         this.nickname = member.getNickName();
         this.birthday = member.getBirthday();
-        this.gender = member.getGenderType();
+        this.genderType = member.getGenderType();
     }
 
     public LocalDate getBirthday() {
@@ -44,7 +44,7 @@ public class MemberResponse {
         return nickname;
     }
 
-    public GenderType getGender() {
-        return gender;
+    public GenderType getGenderType() {
+        return genderType;
     }
 }

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> getUserInfo(@InitAuthentication final Accessor accessor) {
+    public ResponseEntity<MemberResponse> getUserInfo(@Authentication final Accessor accessor) {
         MemberResponse response = memberService.findById(accessor.getId());
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController {
     }
 
     @PutMapping("/profile")
-    public ResponseEntity<Void> updateProfile(
+    public ResponseEntity<Void> updateMemberProfile(
             @Authentication final Accessor accessor,
             @RequestBody final UpdateProfileRequest request) {
         memberService.updateByProfile(accessor.getId(), request);

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package moheng.member.presentation;
 
 import moheng.auth.dto.Accessor;
 import moheng.auth.presentation.authentication.Authentication;
+import moheng.auth.presentation.initauthentication.InitAuthentication;
 import moheng.member.application.MemberService;
 import moheng.member.dto.request.*;
 import moheng.member.dto.response.CheckDuplicateNicknameResponse;
@@ -19,20 +20,20 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> getUserInfo(@Authentication final Accessor accessor) {
+    public ResponseEntity<MemberResponse> getUserInfo(@InitAuthentication final Accessor accessor) {
         MemberResponse response = memberService.findById(accessor.getId());
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/signup/profile")
-    public ResponseEntity<Void> signupProfile(@Authentication final Accessor accessor,
+    public ResponseEntity<Void> signupProfile(@InitAuthentication final Accessor accessor,
                                               @RequestBody final SignUpProfileRequest signUpProfileRequest) {
         memberService.signUpByProfile(accessor.getId(), signUpProfileRequest);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/signup/liveinfo")
-    public ResponseEntity<Void> signupLiveInfo(@Authentication final Accessor accessor,
+    public ResponseEntity<Void> signupLiveInfo(@InitAuthentication final Accessor accessor,
                                                 @RequestBody final SignUpLiveInfoRequest signUpLiveInfoRequest) {
         memberService.signUpByLiveInfo(accessor.getId(), signUpLiveInfoRequest);
         return ResponseEntity.noContent().build();
@@ -47,7 +48,7 @@ public class MemberController {
 
     @PostMapping("/check/nickname")
     public ResponseEntity<CheckDuplicateNicknameResponse> checkDuplicateNickname(
-            @Authentication final Accessor accessor,
+            @InitAuthentication final Accessor accessor,
             @RequestBody final CheckDuplicateNicknameRequest request) {
         memberService.checkIsAlreadyExistNickname(request.getNickname());
         return ResponseEntity.ok(new CheckDuplicateNicknameResponse());

--- a/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
+++ b/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
@@ -5,7 +5,9 @@ import moheng.recommendtrip.domain.RecommendTrip;
 import moheng.recommendtrip.domain.RecommendTripRepository;
 import moheng.trip.domain.Trip;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 public class RecommendTripService {
     private final RecommendTripRepository recommendTripRepository;
@@ -14,6 +16,7 @@ public class RecommendTripService {
         this.recommendTripRepository = recommendTripRepository;
     }
 
+    @Transactional
     public void saveByRank(Trip trip, Member member, long rank) {
         recommendTripRepository.save(new RecommendTrip(trip, member, rank));
     }

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -6,7 +6,9 @@ import moheng.trip.dto.TripCreateRequest;
 import moheng.trip.exception.NoExistTripException;
 import moheng.trip.repository.TripRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 public class TripService {
     private final TripRepository tripRepository;
@@ -27,6 +29,7 @@ public class TripService {
         return trip;
     }
 
+    @Transactional
     public void createTrip(final TripCreateRequest tripCreateRequest) {
         final Trip trip = new Trip(
                 tripCreateRequest.getName(),
@@ -38,6 +41,7 @@ public class TripService {
         tripRepository.save(trip);
     }
 
+    @Transactional
     public void save(final Trip trip) {
         tripRepository.save(trip);
     }

--- a/backend/src/main/java/moheng/trip/domain/Trip.java
+++ b/backend/src/main/java/moheng/trip/domain/Trip.java
@@ -1,6 +1,7 @@
 package moheng.trip.domain;
 
 import jakarta.persistence.*;
+import moheng.global.annotation.Generated;
 import moheng.global.entity.BaseEntity;
 import moheng.trip.exception.InvalidTripDescriptionException;
 import moheng.trip.exception.InvalidTripNameException;
@@ -87,10 +88,12 @@ public class Trip extends BaseEntity {
         return contentId;
     }
 
+    @Generated
     public Long getId() {
         return id;
     }
 
+    @Generated
     public String getDescription() {
         return description;
     }
@@ -99,10 +102,12 @@ public class Trip extends BaseEntity {
         return placeName;
     }
 
+    @Generated
     public String getTripImageUrl() {
         return tripImageUrl;
     }
 
+    @Generated
     public Long getVisitedCount() {
         return visitedCount;
     }

--- a/backend/src/main/java/moheng/trip/domain/Trip.java
+++ b/backend/src/main/java/moheng/trip/domain/Trip.java
@@ -10,7 +10,7 @@ import moheng.trip.exception.InvalidTripNameException;
 @Entity
 public class Trip extends BaseEntity {
     private static final long MAX_NAME_LENGTH = 100;
-    private static final long MIN_NAME_LENGTH = 1;
+    private static final long MIN_NAME_LENGTH = 2;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -64,19 +64,22 @@ public class Trip extends BaseEntity {
 
     void validateName(String name) {
         if(name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH ) {
-            throw new InvalidTripNameException("여행지 이름의 길이는 100자 이하, 1자 이상만 허용됩니다.");
+            throw new InvalidTripNameException("여행지 이름의 길이는 100자 이하, 2자 이상만 허용됩니다.");
         }
     }
 
     void validatePlaceName(String placeName) {
         if(placeName.length() < MIN_NAME_LENGTH || placeName.length() > MAX_NAME_LENGTH ) {
-            throw new InvalidTripNameException("여행지 장소명의 길이는 100자 이하, 1자 이상만 허용됩니다.");
+            throw new InvalidTripNameException("여행지 장소명의 길이는 100자 이하, 2자 이상만 허용됩니다.");
         }
     }
 
     void validateDescription(String description) {
         if(description.isEmpty() || description == null) {
             throw new InvalidTripDescriptionException("여행지 설명은 비어있을 수 없습니다.");
+        }
+        if(description.length() < MIN_NAME_LENGTH) {
+            throw new InvalidTripDescriptionException("여행지 설명의 길이는 2자 이상만 허용됩니다.");
         }
     }
 

--- a/backend/src/test/java/moheng/acceptance/LiveInformationAcceptenceTest.java
+++ b/backend/src/test/java/moheng/acceptance/LiveInformationAcceptenceTest.java
@@ -73,16 +73,10 @@ public class LiveInformationAcceptenceTest extends AcceptanceTestConfig {
         ExtractableResponse<Response> liveInfoSignUpResponse = 생활정보로_회원가입_한다(accessTokenResponse);
 
         // when
-        ExtractableResponse<Response> resultResponse = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2(accessTokenResponse.getAccessToken())
-                .when().get("/live/info/member")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
-
+        ExtractableResponse<Response> resultResponse = 멤버의_생활정보를_찾는다(accessTokenResponse);
         FindMemberLiveInformationResponses memberLiveInfoResponse = resultResponse.as(FindMemberLiveInformationResponses.class);
 
+        // then
         assertAll(() -> {
             상태코드_200이_반환된다(resultResponse);
             assertThat(memberLiveInfoResponse.getLiveInfoResponses()).hasSize(5);

--- a/backend/src/test/java/moheng/acceptance/MemberLiveInfoAcceptenceTest.java
+++ b/backend/src/test/java/moheng/acceptance/MemberLiveInfoAcceptenceTest.java
@@ -1,0 +1,41 @@
+package moheng.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import moheng.acceptance.config.AcceptanceTestConfig;
+import moheng.auth.dto.AccessTokenResponse;
+import moheng.member.dto.response.MemberResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static moheng.acceptance.fixture.AuthAcceptanceFixture.자체_토큰을_생성한다;
+import static moheng.acceptance.fixture.HttpStatus.상태코드_200이_반환된다;
+import static moheng.acceptance.fixture.HttpStatus.상태코드_204이_반환된다;
+import static moheng.acceptance.fixture.LiveInfoAcceptenceFixture.생활정보를_생성한다;
+import static moheng.acceptance.fixture.MemberLiveInfoAcceptenceFixture.*;
+import static moheng.acceptance.fixture.LiveInfoAcceptenceFixture.*;
+import static moheng.acceptance.fixture.MemberAcceptanceFixture.회원_본인의_정보를_조회한다;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class MemberLiveInfoAcceptenceTest extends AcceptanceTestConfig {
+
+    @DisplayName("멤버 생활정보 수정에 성공하면 상태코드 204를 리턴한다.")
+    @Test
+    void 멤버_생활정보_수정에_성공하면_상태코드_204를_리턴한다() {
+        // given
+        ExtractableResponse<Response> loginResponse = 자체_토큰을_생성한다("KAKAO", "authorization-code");
+        AccessTokenResponse accessTokenResponse = loginResponse.as(AccessTokenResponse.class);
+
+        생활정보를_생성한다("생활정보1");
+        생활정보를_생성한다("생활정보2");
+
+        // when
+        ExtractableResponse<Response> resultResponse = 회원의_생활정보를_수정한다(accessTokenResponse.getAccessToken());
+
+        // then
+        assertAll(() -> {
+            상태코드_204이_반환된다(resultResponse);
+        });
+    }
+}

--- a/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
@@ -3,6 +3,7 @@ package moheng.acceptance.fixture;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import moheng.auth.dto.AccessTokenResponse;
 import moheng.liveinformation.dto.LiveInformationCreateRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,6 +23,16 @@ public class LiveInfoAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/live/info/all")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 멤버의_생활정보를_찾는다(AccessTokenResponse accessTokenResponse) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(accessTokenResponse.getAccessToken())
+                .when().get("/live/info/member")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
@@ -21,7 +21,7 @@ public class LiveInfoAcceptenceFixture {
     public static ExtractableResponse<Response> 모든_생활정보를_찾는다() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/live/info")
+                .when().get("/live/info/all")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/MemberLiveInfoAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/MemberLiveInfoAcceptenceFixture.java
@@ -1,0 +1,24 @@
+package moheng.acceptance.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import moheng.liveinformation.dto.LiveInformationCreateRequest;
+import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+public class MemberLiveInfoAcceptenceFixture {
+    public static ExtractableResponse<Response> 회원의_생활정보를_수정한다(String accessToken) {
+        return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new UpdateMemberLiveInformationRequest(List.of(1L, 2L)))
+                .when().put("/live/info/member")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value())
+                .extract();
+    }
+}

--- a/backend/src/test/java/moheng/auth/domain/KakaoOAuthClientTest.java
+++ b/backend/src/test/java/moheng/auth/domain/KakaoOAuthClientTest.java
@@ -1,0 +1,22 @@
+package moheng.auth.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import moheng.auth.domain.oauth.KakaoOAuthClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class KakaoOAuthClientTest {
+    @Autowired
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @DisplayName("OAuth 클라이언트 식별자가 동일하다면 참을 리턴한다.")
+    @Test
+    void OAuth_클라이언트_식별자가_동일하다면_참을_리턴한다() {
+        // given, when, then
+        assertTrue(kakaoOAuthClient.isSame("KAKAO"));
+    }
+}

--- a/backend/src/test/java/moheng/auth/domain/KakaoUriProviderTest.java
+++ b/backend/src/test/java/moheng/auth/domain/KakaoUriProviderTest.java
@@ -1,0 +1,21 @@
+package moheng.auth.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import moheng.auth.domain.oauth.KakaoUriProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class KakaoUriProviderTest {
+    @Autowired
+    private KakaoUriProvider kakaoUriProvider;
+
+    @DisplayName("OAuth URI 제공처 식별자가 동일하다면 참을 리턴한다.")
+    @Test
+    void OAuth_URI_제공처_식별자가_동일하다면_참을_리턴한다() {
+        assertTrue(kakaoUriProvider.isSame("KAKAO"));
+    }
+}

--- a/backend/src/test/java/moheng/config/ControllerTestConfig.java
+++ b/backend/src/test/java/moheng/config/ControllerTestConfig.java
@@ -8,6 +8,7 @@ import moheng.auth.domain.token.TokenManager;
 import moheng.auth.presentation.authentication.AuthenticationArgumentResolver;
 import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
 import moheng.liveinformation.application.LiveInformationService;
+import moheng.liveinformation.application.MemberLiveInformationService;
 import moheng.member.application.MemberService;
 import moheng.trip.application.TripService;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,4 +59,7 @@ public abstract class ControllerTestConfig {
 
     @MockBean
     protected TripService tripService;
+
+    @MockBean
+    protected MemberLiveInformationService memberLiveInformationService;
 }

--- a/backend/src/test/java/moheng/config/ControllerTestConfig.java
+++ b/backend/src/test/java/moheng/config/ControllerTestConfig.java
@@ -10,6 +10,7 @@ import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
 import moheng.liveinformation.application.LiveInformationService;
 import moheng.liveinformation.application.MemberLiveInformationService;
 import moheng.member.application.MemberService;
+import moheng.member.domain.repository.MemberRepository;
 import moheng.trip.application.TripService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -62,4 +63,7 @@ public abstract class ControllerTestConfig {
 
     @MockBean
     protected MemberLiveInformationService memberLiveInformationService;
+
+    @MockBean
+    protected MemberRepository memberRepository;
 }

--- a/backend/src/test/java/moheng/fixture/MemberFixtures.java
+++ b/backend/src/test/java/moheng/fixture/MemberFixtures.java
@@ -1,5 +1,6 @@
 package moheng.fixture;
 
+import moheng.auth.domain.oauth.Authority;
 import moheng.member.domain.GenderType;
 import moheng.member.domain.Member;
 import moheng.member.domain.SocialType;

--- a/backend/src/test/java/moheng/fixture/MemberLiveInfoFixture.java
+++ b/backend/src/test/java/moheng/fixture/MemberLiveInfoFixture.java
@@ -1,0 +1,12 @@
+package moheng.fixture;
+
+import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
+import moheng.member.dto.request.SignUpInterestTripsRequest;
+
+import java.util.List;
+
+public class MemberLiveInfoFixture {
+    public static UpdateMemberLiveInformationRequest 멤버_생활정보_수정_요청() {
+        return new UpdateMemberLiveInformationRequest(List.of(1L, 2L, 3L));
+    }
+}

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -1,6 +1,7 @@
 package moheng.liveinformation.application;
 
 import static moheng.fixture.MemberFixtures.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,6 +13,7 @@ import moheng.liveinformation.dto.LiveInfoResponse;
 import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
 import moheng.member.application.MemberService;
 import moheng.member.domain.Member;
+import moheng.member.exception.NoExistMemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,6 +86,19 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
         // when, then
         UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
         assertDoesNotThrow(() -> memberLiveInformationService.updateMemberLiveInformation(member.getId(), request));
+    }
+
+    @DisplayName("존재하지 않는 멤버의 생활정보 리스트를 수정하면 예외가 발생한다.")
+    @Test
+    void 존재하지_않는_멤버의_생활정보_리스트를_수정하면_예외가_발생한다() {
+        // given
+        LiveInformation liveInformation1 = liveInformationService.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationService.save(new LiveInformation("생활정보2"));
+
+        // when, then
+        UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
+        assertThatThrownBy(() -> memberLiveInformationService.updateMemberLiveInformation(-1L, request))
+                .isInstanceOf(NoExistMemberException.class);
     }
 
     @DisplayName("생활정보를 수정시 멤버의 기존 생활정보를 모두 삭제하고 새로운 생활정보를 생성한다.")

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -2,14 +2,13 @@ package moheng.liveinformation.application;
 
 import static moheng.fixture.MemberFixtures.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import moheng.config.ServiceTestConfig;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.domain.MemberLiveInformation;
-import moheng.liveinformation.domain.MemberLiveInformationService;
 import moheng.member.application.MemberService;
 import moheng.member.domain.Member;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,5 +42,26 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
 
         // when, then
         assertDoesNotThrow(() -> memberLiveInformationService.saveAll(memberLiveInformations));
+    }
+
+    @DisplayName("멤버가 선택한 생활정보와 선택하지 않은 생활정보를 모두 조회한다.")
+    @Test
+    void 멤버가_선택한_생활정보와_선택하지_않은_생화정보를_모두_조회한다() {
+        // given
+        memberService.save(하온_기존());
+        Member member = memberService.findByEmail(하온_이메일);
+
+        LiveInformation liveInformation1 = liveInformationService.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationService.save(new LiveInformation("생활정보2"));
+        LiveInformation liveInformation3 = liveInformationService.save(new LiveInformation("생활정보3"));
+
+        MemberLiveInformation memberLiveInformation1 = new MemberLiveInformation(liveInformation1, member);
+        MemberLiveInformation memberLiveInformation2 = new MemberLiveInformation(liveInformation2, member);
+        List<MemberLiveInformation> memberLiveInformations = new ArrayList<>(List.of(memberLiveInformation1, memberLiveInformation2));
+
+        memberLiveInformationService.saveAll(memberLiveInformations);
+
+        // when, then
+        assertThat(memberLiveInformationService.findMemberSelectedLiveInformation(member.getId()).getLiveInfoResponses()).hasSize(3);
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -103,10 +103,10 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
         memberLiveInformationService.saveAll(oldMemberLiveInformations);
 
         // when
-        UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
+        UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L, 3L));
         memberLiveInformationService.updateMemberLiveInformation(member.getId(), request);
 
         // then
-         assertThat(memberLiveInformationService.findMemberLiveInfoIds(member.getId())).hasSize(2);
+         assertThat(memberLiveInformationService.findMemberLiveInfoIds(member.getId())).hasSize(3);
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -85,4 +85,28 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
         UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
         assertDoesNotThrow(() -> memberLiveInformationService.updateMemberLiveInformation(member.getId(), request));
     }
+
+    @DisplayName("생활정보를 수정시 멤버의 기존 생활정보를 모두 삭제하고 새로운 생활정보를 생성한다.")
+    @Test
+    void 생활정보를_수정시_멤버의_기존_생활정보를_모두_삭제하고_새로운_생활정보를_생성한다() {
+        // given
+        memberService.save(하온_기존());
+        Member member = memberService.findByEmail(하온_이메일);
+
+        LiveInformation liveInformation1 = liveInformationService.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationService.save(new LiveInformation("생활정보2"));
+        LiveInformation liveInformation3 = liveInformationService.save(new LiveInformation("생활정보3"));
+
+        MemberLiveInformation oldMemberLiveInformation1 = new MemberLiveInformation(liveInformation1, member);
+        MemberLiveInformation oldMemberLiveInformation2 = new MemberLiveInformation(liveInformation2, member);
+        List<MemberLiveInformation> oldMemberLiveInformations = new ArrayList<>(List.of(oldMemberLiveInformation1, oldMemberLiveInformation2));
+        memberLiveInformationService.saveAll(oldMemberLiveInformations);
+
+        // when
+        UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
+        memberLiveInformationService.updateMemberLiveInformation(member.getId(), request);
+
+        // then
+         assertThat(memberLiveInformationService.findMemberLiveInfoIds(member.getId())).hasSize(2);
+    }
 }

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -9,6 +9,7 @@ import moheng.config.ServiceTestConfig;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.domain.MemberLiveInformation;
 import moheng.liveinformation.dto.LiveInfoResponse;
+import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
 import moheng.member.application.MemberService;
 import moheng.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -68,5 +69,20 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
 
         // then
         assertThat(expected).hasSize(3);
+    }
+
+    @DisplayName("멤버의 생활정보를 수정한다.")
+    @Test
+    void 멤버의_생활정보를_수정한다() {
+        // given
+        memberService.save(하온_기존());
+        Member member = memberService.findByEmail(하온_이메일);
+
+        LiveInformation liveInformation1 = liveInformationService.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationService.save(new LiveInformation("생활정보2"));
+
+        // when, then
+        UpdateMemberLiveInformationRequest request = new UpdateMemberLiveInformationRequest(List.of(1L, 2L));
+        assertDoesNotThrow(() -> memberLiveInformationService.updateMemberLiveInformation(member.getId(), request));
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -1,12 +1,14 @@
 package moheng.liveinformation.application;
 
 import static moheng.fixture.MemberFixtures.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import moheng.config.ServiceTestConfig;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.domain.MemberLiveInformation;
+import moheng.liveinformation.dto.LiveInfoResponse;
 import moheng.member.application.MemberService;
 import moheng.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -61,7 +63,10 @@ public class MemberLiveInformationServiceTest extends ServiceTestConfig {
 
         memberLiveInformationService.saveAll(memberLiveInformations);
 
-        // when, then
-        assertThat(memberLiveInformationService.findMemberSelectedLiveInformation(member.getId()).getLiveInfoResponses()).hasSize(3);
+        // when
+        List<LiveInfoResponse> expected = memberLiveInformationService.findMemberSelectedLiveInformation(member.getId()).getLiveInfoResponses();
+
+        // then
+        assertThat(expected).hasSize(3);
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import moheng.liveinformation.exception.LiveInfoNameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class LiveInformationTest {
     @DisplayName("생활정보를 생성한다.")
@@ -17,9 +19,10 @@ public class LiveInformationTest {
     }
 
     @DisplayName("생활정보 이름의 길이가 올바르지 않다면 예외가 발생한다.")
-    @Test
-    void 생활정보_이름의_길이가_올바르지_않다면_예외가_발생한다() {
+    @ParameterizedTest
+    @ValueSource(strings = {"", "일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 일이삼자오육칠팔구십 "})
+    void 생활정보_이름의_길이가_올바르지_않다면_예외가_발생한다(final String name) {
         // given, when, then
-        assertThatThrownBy(() -> new LiveInformation("")).isInstanceOf(LiveInfoNameException.class);
+        assertThatThrownBy(() -> new LiveInformation(name)).isInstanceOf(LiveInfoNameException.class);
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
@@ -1,0 +1,17 @@
+package moheng.liveinformation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class LiveInformationTest {
+    @DisplayName("생활정보를 생성한다.")
+    @Test
+    void 생활정보를_생성한다() {
+        // given, when, then
+        assertDoesNotThrow(() -> new LiveInformation("생활정보1"));
+    }
+}

--- a/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/LiveInformationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import moheng.liveinformation.exception.LiveInfoNameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,5 +14,12 @@ public class LiveInformationTest {
     void 생활정보를_생성한다() {
         // given, when, then
         assertDoesNotThrow(() -> new LiveInformation("생활정보1"));
+    }
+
+    @DisplayName("생활정보 이름의 길이가 올바르지 않다면 예외가 발생한다.")
+    @Test
+    void 생활정보_이름의_길이가_올바르지_않다면_예외가_발생한다() {
+        // given, when, then
+        assertThatThrownBy(() -> new LiveInformation("")).isInstanceOf(LiveInfoNameException.class);
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
@@ -28,6 +28,25 @@ public class MemberLiveInformationRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private LiveInformationRepository liveInformationRepository;
 
+    @DisplayName("멤버의 생활정보를 찾는다.")
+    @Test
+    void 멤버의_생활정보를_찾는다() {
+        // given
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).get();
+
+        LiveInformation liveInformation1 = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationRepository.save(new LiveInformation("생활정보2"));
+
+        MemberLiveInformation memberLiveInformation1 = new MemberLiveInformation(liveInformation1, member);
+        MemberLiveInformation memberLiveInformation2 = new MemberLiveInformation(liveInformation2, member);
+        List<MemberLiveInformation> memberLiveInformations = new ArrayList<>(List.of(memberLiveInformation1, memberLiveInformation2));
+        memberLiveInformationRepository.saveAll(memberLiveInformations);
+
+        // when, then
+        assertThat(memberLiveInformationRepository.findByMemberId(member.getId())).hasSize(2);
+    }
+
     @DisplayName("멤버의 생활정보를 삭제한다.")
     @Test
     void 멤버의_생활정보를_삭제한다() {

--- a/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
@@ -1,0 +1,52 @@
+package moheng.liveinformation.domain;
+
+import static moheng.fixture.MemberFixtures.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import moheng.config.RepositoryTestConfig;
+import moheng.config.TestConfig;
+import moheng.member.domain.Member;
+import moheng.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpringBootTest(classes = TestConfig.class)
+public class MemberLiveInformationRepositoryTest extends RepositoryTestConfig {
+    @Autowired
+    private MemberLiveInformationRepository memberLiveInformationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private LiveInformationRepository liveInformationRepository;
+
+    @DisplayName("멤버의 생활정보를 삭제한다.")
+    @Test
+    void 멤버의_생활정보를_삭제한다() {
+        // given
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).get();
+
+        LiveInformation liveInformation1 = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        LiveInformation liveInformation2 = liveInformationRepository.save(new LiveInformation("생활정보2"));
+
+        MemberLiveInformation memberLiveInformation1 = new MemberLiveInformation(liveInformation1, member);
+        MemberLiveInformation memberLiveInformation2 = new MemberLiveInformation(liveInformation2, member);
+        List<MemberLiveInformation> memberLiveInformations = new ArrayList<>(List.of(memberLiveInformation1, memberLiveInformation2));
+        memberLiveInformationRepository.saveAll(memberLiveInformations);
+
+        // when
+        memberLiveInformationRepository.deleteByMemberId(member.getId());
+
+        // then
+        assertThat(memberLiveInformationRepository.count()).isEqualTo(0);
+    }
+}

--- a/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
@@ -41,7 +41,7 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
                 ));
 
         // when, then
-        mockMvc.perform(get("/live/info")
+        mockMvc.perform(get("/live/info/all")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
         )

--- a/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
@@ -19,6 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import moheng.config.ControllerTestConfig;
 import moheng.liveinformation.domain.LiveInformation;
 import moheng.liveinformation.dto.FindAllLiveInformationResponse;
+import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import moheng.liveinformation.dto.LiveInfoResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -70,5 +72,26 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
                 .content(objectMapper.writeValueAsString(비어있는_생활정보로_회원가입_요청()))
         ).andDo(print())
                 .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("멤버가 선택한 생활정보를 조회하고 상태코드 200을 리턴한다.")
+    @Test
+    void 멤버가_선택한_생활정보를_조회하고_상태코드_200을_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberLiveInformationService.findMemberSelectedLiveInformation(anyLong()))
+                .willReturn(new FindMemberLiveInformationResponses( List.of(
+                        new LiveInfoResponse(1L, "생활정보1", true),
+                        new LiveInfoResponse(2L, "생활정보2", true),
+                        new LiveInfoResponse(3L, "생활정보3", false)
+                )));
+
+        // when, then
+        mockMvc.perform(get("/live/info/member")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
@@ -73,35 +73,4 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
         ).andDo(print())
                 .andExpect(status().isNoContent());
     }
-
-    @DisplayName("멤버가 선택한 생활정보를 조회하고 상태코드 200을 리턴한다.")
-    @Test
-    void 멤버가_선택한_생활정보를_조회하고_상태코드_200을_리턴한다() throws Exception {
-        // given
-        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
-        given(memberLiveInformationService.findMemberSelectedLiveInformation(anyLong()))
-                .willReturn(new FindMemberLiveInformationResponses( List.of(
-                        new LiveInfoResponse(1L, "생활정보1", true),
-                        new LiveInfoResponse(2L, "생활정보2", true),
-                        new LiveInfoResponse(3L, "생활정보3", false)
-                )));
-
-        // when, then
-        mockMvc.perform(get("/live/info/member")
-                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andDo(document("live/info/member",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        responseFields(
-                                fieldWithPath("liveInfoResponses").description("멤버가 선택한, 선택하지 않은 모든 생활정보"),
-                                fieldWithPath("liveInfoResponses[].liveInfoId").description("생활정보 ID"),
-                                fieldWithPath("liveInfoResponses[].name").description("생활정보 이름"),
-                                fieldWithPath("liveInfoResponses[].contain").description("멤버의 생활정보 보유(선택) 여부")
-                        )
-                ))
-                .andExpect(status().isOk());
-    }
 }

--- a/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
@@ -92,6 +92,16 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
+                .andDo(document("live/info/member",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("liveInfoResponses").description("멤버가 선택한, 선택하지 않은 모든 생활정보"),
+                                fieldWithPath("liveInfoResponses[].liveInfoId").description("생활정보 ID"),
+                                fieldWithPath("liveInfoResponses[].name").description("생활정보 이름"),
+                                fieldWithPath("liveInfoResponses[].contain").description("멤버의 생활정보 보유(선택) 여부")
+                        )
+                ))
                 .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
@@ -7,8 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -42,7 +41,7 @@ public class MemberLiveInfoControllerTest extends ControllerTestConfig {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("live/info/member",
+                .andDo(document("live/info/member/find",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(
@@ -69,6 +68,13 @@ public class MemberLiveInfoControllerTest extends ControllerTestConfig {
                         .content(objectMapper.writeValueAsString(멤버_생활정보_수정_요청()))
                 )
                 .andDo(print())
+                .andDo(document("live/info/member/update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("liveInfoIds").description("멤버가 새롭게 수정하고자 선택한 생활정보 id 리스트")
+                        )
+                ))
                 .andExpect(status().isNoContent());
     }
 }

--- a/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
@@ -1,0 +1,74 @@
+package moheng.liveinformation.presentation;
+
+import static moheng.fixture.MemberLiveInfoFixture.*;
+import static moheng.fixture.MemberFixtures.프로필_업데이트_요청;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import moheng.config.ControllerTestConfig;
+import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import moheng.liveinformation.dto.LiveInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import java.util.List;
+
+public class MemberLiveInfoControllerTest extends ControllerTestConfig {
+
+    @DisplayName("멤버가 선택한 생활정보를 조회하고 상태코드 200을 리턴한다.")
+    @Test
+    void 멤버가_선택한_생활정보를_조회하고_상태코드_200을_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberLiveInformationService.findMemberSelectedLiveInformation(anyLong()))
+                .willReturn(new FindMemberLiveInformationResponses( List.of(
+                        new LiveInfoResponse(1L, "생활정보1", true),
+                        new LiveInfoResponse(2L, "생활정보2", true),
+                        new LiveInfoResponse(3L, "생활정보3", false)
+                )));
+
+        // when, then
+        mockMvc.perform(get("/live/info/member")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("live/info/member",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("liveInfoResponses").description("멤버가 선택한, 선택하지 않은 모든 생활정보"),
+                                fieldWithPath("liveInfoResponses[].liveInfoId").description("생활정보 ID"),
+                                fieldWithPath("liveInfoResponses[].name").description("생활정보 이름"),
+                                fieldWithPath("liveInfoResponses[].contain").description("멤버의 생활정보 보유(선택) 여부")
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("멤버의 생활정보를 수정하고 상태코드 204를 리턴한다.")
+    @Test
+    void 멤버의_생활정보를_수정하고_상태코드_204를_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+
+        // when, then
+        mockMvc.perform(put("/live/info/member")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(멤버_생활정보_수정_요청()))
+                )
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+}

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -177,11 +177,12 @@ public class MemberServiceTest extends ServiceTestConfig {
         // given
         memberService.save(하온_기존());
         memberService.save(래오_기존());
+        Member member = memberService.findByEmail(하온_이메일);
 
         UpdateProfileRequest request = new UpdateProfileRequest(래오_닉네임, 하온_생년월일, 하온_성별, 하온_프로필_경로);
 
         // when, then
-        assertThatThrownBy(() -> memberService.updateByProfile(1L, request))
+        assertThatThrownBy(() -> memberService.updateByProfile(member.getId(), request))
                 .isInstanceOf(DuplicateNicknameException.class);
     }
 
@@ -232,6 +233,19 @@ public class MemberServiceTest extends ServiceTestConfig {
         memberService.save(하온_기존());
         long memberId = memberService.findByEmail(하온_이메일).getId();
         SignUpLiveInfoRequest request = new SignUpLiveInfoRequest(new ArrayList<>());
+
+        // when, then
+        assertThatThrownBy(() -> memberService.signUpByLiveInfo(memberId, request))
+                .isInstanceOf(EmptyLiveInformationException.class);
+    }
+
+    @DisplayName("생활정보를 선택하지 않고 null 을 전달하면 예외가 발생한다.")
+    @Test
+    void 생활정보를_선택하지_않고_null을_전달하면_예외가_발생한다() {
+        // given
+        memberService.save(하온_기존());
+        long memberId = memberService.findByEmail(하온_이메일).getId();
+        SignUpLiveInfoRequest request = new SignUpLiveInfoRequest(null);
 
         // when, then
         assertThatThrownBy(() -> memberService.signUpByLiveInfo(memberId, request))

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -269,6 +269,21 @@ public class MemberServiceTest extends ServiceTestConfig {
         assertDoesNotThrow(() -> memberService.signUpByInterestTrips(memberId, request));
     }
 
+    @DisplayName("존재하지 않는 회원의 관심 여행지를 저장하면 예외가 발생한다.")
+    @Test
+    void 존재하지_않는_회원의_관심_여행지를_저장하면_예외가_발생한다() {
+        // given
+        for(long contentId=1; contentId<=5; contentId++) {
+            tripService.save(new Trip("롯데월드", "서울특별시 송파구", contentId,
+                    "설명", "https://image.com"));
+        }
+        SignUpInterestTripsRequest request = new SignUpInterestTripsRequest(List.of(1L, 2L, 3L, 4L, 5L));
+
+        // when, then
+        assertThatThrownBy(() -> memberService.signUpByInterestTrips(-1L, request))
+                .isInstanceOf(NoExistMemberException.class);
+    }
+
     @DisplayName("회원의 관심 여행지가 5개 미만이라면 예외가 발생한다.")
     @Test
     void 회원의_관심_여행지가_5개_미만이라면_예외가_발생한다() {

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -171,6 +171,20 @@ public class MemberServiceTest extends ServiceTestConfig {
                 .isInstanceOf(NoExistMemberException.class);
     }
 
+    @DisplayName("기존 닉네임과 다르다면 해당 닉네임을 가진 다른 유저의 닉네임과 중복 여부를 확인한다.")
+    @Test
+    void 기존_닉네임과_다르다면_해당_닉네임을_가진_다른_유저의_닉네임과_중복_여부를_확인한다() {
+        // given
+        memberService.save(하온_기존());
+        memberService.save(래오_기존());
+
+        UpdateProfileRequest request = new UpdateProfileRequest(래오_닉네임, 하온_생년월일, 하온_성별, 하온_프로필_경로);
+
+        // when, then
+        assertThatThrownBy(() -> memberService.updateByProfile(1L, request))
+                .isInstanceOf(DuplicateNicknameException.class);
+    }
+
     @DisplayName("회원 본인을 제외한 다른 회원들중에 닉네임이 중복된다면 예외가 발생한다.")
     @Test
     void 회원_본인을_제외한_다른_회원들중에_닉네임이_중복된다면_예외가_발생한다() {

--- a/backend/src/test/java/moheng/member/domain/MemberTest.java
+++ b/backend/src/test/java/moheng/member/domain/MemberTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import moheng.auth.domain.oauth.Authority;
 import moheng.member.exception.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -98,5 +99,13 @@ public class MemberTest {
     void 기존_닉네임과_다르다면_참을_리턴한다() {
         // given, when, then
         assertThat(하온_기존().isNicknameChanged("other nickname")).isTrue();
+    }
+
+    @DisplayName("권한을 변경한다.")
+    @Test
+    void 권한을_변경한다() {
+        Member member = new Member(하온_이메일, 하온_소셜_타입_카카오);
+        member.changePrivilege(Authority.REGULAR_MEMBER);
+        assertThat(member.getAuthority()).isEqualTo(Authority.REGULAR_MEMBER);
     }
 }

--- a/backend/src/test/java/moheng/member/domain/MemberTest.java
+++ b/backend/src/test/java/moheng/member/domain/MemberTest.java
@@ -9,6 +9,8 @@ import moheng.member.exception.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,19 +34,26 @@ public class MemberTest {
     }
 
     @DisplayName("이메일 형식이 올바르지 않다면 예외가 발생한다.")
-    @Test
-    void 이메일_형식이_올바르지_않다면_예외가_발생한다() {
+    @ValueSource(strings = {"dev.haon@", "dev.haonkakao.com", "dev.haon", "dev.haon@gmail", "@gmail.com"})
+    @ParameterizedTest
+    void 이메일_형식이_올바르지_않다면_예외가_발생한다(final String email) {
         // given, when, then
-        assertThatThrownBy(() -> new Member("invalid email", 하온_소셜_타입_구글))
+        assertThatThrownBy(() -> new Member(email, 하온_소셜_타입_구글))
                 .isInstanceOf(InvalidEmailFormatException.class);
     }
 
     @DisplayName("닉네임 형식이 올바르지 않다면 예외가 발생한다.")
-    @Test
-    void 닉네임_형식이_올바르지_않다면_예외가_발생한다() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "qweiqnweiqnweiqwieqniweiqweiqwneiqnweqwienwqeqieqnweiqwneiqwenqweiqnweiqweqweqweqweinqwneiqwei",
+            "",
+            "a",
+            "오"
+    })
+    void 닉네임_형식이_올바르지_않다면_예외가_발생한다(final String nickname) {
         // given, when, then
         assertThatThrownBy(() -> new Member(1L, 하온_이메일,
-                "qweiqnweiqnweiqwieqniweiqweiqwneiqnweqwienwqeqieqnweiqwneiqwenqweiqnweiqweqweqweqweinqwneiqwei",
+                nickname,
                 하온_프로필_경로, 하온_소셜_타입_카카오, 하온_생년월일, 하온_성별))
                 .isInstanceOf(InvalidNicknameFormatException.class);
     }
@@ -69,12 +78,18 @@ public class MemberTest {
     }
 
     @DisplayName("생년월일이 현재 날짜보다 이후라면 예외가 발생한다.")
-    @Test
-    void 생년월일이_현재_날짜보다_이후라면_예외가_발생한다() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "3000-01-01",
+            "2500-01-01",
+            "2300-06-18",
+            "5000-12-31"
+    })
+    void 생년월일이_현재_날짜보다_이후라면_예외가_발생한다(LocalDate date) {
         // given, when, then
         assertThatThrownBy(() -> new Member(1L, 하온_이메일,
                 하온_닉네임, 하온_프로필_경로,
-                하온_소셜_타입_카카오, LocalDate.of(2200, 1, 1), 하온_성별))
+                하온_소셜_타입_카카오, date, 하온_성별))
                 .isInstanceOf(InvalidBirthdayException.class);
     }
 

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -42,8 +44,6 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberService.findById(anyLong())).willReturn(하온_응답());
 
         // when, then
-
-
     }
 
     @DisplayName("프로필 정보로 회원가입에 성공하면 상태코드 204을 리턴한다.")
@@ -51,6 +51,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 프로필_정보로_회원가입에_성공하면_상태코드_204을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
 
         // when, then
         mockMvc.perform(post("/member/signup/profile")
@@ -81,6 +82,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 중복되는_닉네임_없이_사용_가능한_닉네임이라면_메시지와_상태코드_200을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
 
         // when, then
         mockMvc.perform(post("/member/check/nickname")
@@ -110,6 +112,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 중복되는_닉네임이_존재한다면_상태코드_401을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
         doThrow(new DuplicateNicknameException("중복되는 닉네임이 존재합니다."))
                 .when(memberService).checkIsAlreadyExistNickname(anyString());
 
@@ -201,6 +204,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 여행지_추천에_필요한_생활정보를_입력하여_회원가입에_성공하면_상태코드_204를_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
         doNothing().when(memberService).signUpByLiveInfo(anyLong(), any());
 
         // when, then
@@ -227,6 +231,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 전달받은_여행지_추천에_필요한_생활정보_리스트가_비어있거나_유효하지_않다면_상태코드_400을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
         doThrow(new EmptyLiveInformationException("생활정보를 선택하지 않았습니다."))
                 .when(memberService).signUpByLiveInfo(anyLong(), any());
 

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -9,6 +9,7 @@ import moheng.auth.dto.TokenRequest;
 import moheng.auth.exception.InvalidTokenException;
 import moheng.config.ControllerTestConfig;
 import moheng.liveinformation.exception.EmptyLiveInformationException;
+import moheng.member.domain.GenderType;
 import moheng.member.dto.response.MemberResponse;
 import moheng.member.exception.DuplicateNicknameException;
 import moheng.member.exception.ShortContentidsSizeException;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -44,6 +46,27 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberService.findById(anyLong())).willReturn(하온_응답());
 
         // when, then
+        mockMvc.perform(get("/member/me")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andDo(document("member/me",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("엑세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("고유 id 값"),
+                                fieldWithPath("profileImageUrl").description("프로필 이미지 경로"),
+                                fieldWithPath("nickname").description("성별. 형식: MEN 또는 WOMEN"),
+                                fieldWithPath("birthday").description("생년월일. 형식:yyyy-MM-dd"),
+                                fieldWithPath("genderType").description("프로필 이미지 경로.")
+                        )
+                ))
+                .andExpect(status().isOk());
     }
 
     @DisplayName("프로필 정보로 회원가입에 성공하면 상태코드 204을 리턴한다.")

--- a/backend/src/test/java/moheng/trip/domain/TripTest.java
+++ b/backend/src/test/java/moheng/trip/domain/TripTest.java
@@ -1,12 +1,17 @@
 package moheng.trip.domain;
 
+import static moheng.fixture.MemberFixtures.하온_소셜_타입_구글;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
+import moheng.member.domain.Member;
+import moheng.member.exception.InvalidEmailFormatException;
 import moheng.trip.exception.InvalidTripDescriptionException;
 import moheng.trip.exception.InvalidTripNameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TripTest {
 
@@ -20,10 +25,9 @@ public class TripTest {
     }
 
     @DisplayName("여행지 이름의 길이가 유효하지 않다면 예외가 발생한다.")
-    @Test
-    void 여행지_이름의_길이가_유효하지_않다면_예외가_발생한다() {
-        String name = "";
-
+    @ValueSource(strings = {"", "a", "여", "행", "일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 "})
+    @ParameterizedTest
+    void 여행지_이름의_길이가_유효하지_않다면_예외가_발생한다(final String name) {
         assertThatThrownBy(() -> new Trip(name, "서울특별시 송파구", 1000000L,
                 "서울 롯데월드는 신나는 여가와 엔터테인먼트를 꿈꾸는 사람들과 갈수록 늘어나는 외국인 관광 활성화를 위해 운영하는 테마파크예요.",
                 "https://lotte-world-image.png"))
@@ -31,11 +35,10 @@ public class TripTest {
     }
 
     @DisplayName("여행지 장소명의 길이가 유효하지 않다면 예외가 발생한다.")
-    @Test
-    void 여행지_장소명의_길이가_유효하지_않다면_예외가_발생한다() {
+    @ValueSource(strings = {"", "a", "여", "행", "일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 일이삼사오육칠팔구십 "})
+    @ParameterizedTest
+    void 여행지_장소명의_길이가_유효하지_않다면_예외가_발생한다(final String placeName) {
         // given, when, then
-        String placeName = "";
-
         assertThatThrownBy(() -> new Trip("롯데월드", placeName, 1000000L,
                 "서울 롯데월드는 신나는 여가와 엔터테인먼트를 꿈꾸는 사람들과 갈수록 늘어나는 외국인 관광 활성화를 위해 운영하는 테마파크예요.",
                 "https://lotte-world-image.png"))
@@ -43,16 +46,13 @@ public class TripTest {
     }
 
     @DisplayName("여행지에 대한 설명이 유효하지 않다면 예외가 발생한다")
-    @Test
-    void 여행지에_대한_설명이_유효하지_않다면_예외가_발생한다() {
+    @ValueSource(strings = {"", "a", "여", "행"})
+    @ParameterizedTest
+    void 여행지에_대한_설명이_유효하지_않다면_예외가_발생한다(final String description) {
         // given, when, then
-        String descprtion = "";
-
         assertThatThrownBy(() -> new Trip("롯데월드", "서울특별시 송파구", 1000000L,
-                descprtion,
+                description,
                 "https://lotte-world-image.png"))
                 .isInstanceOf(InvalidTripDescriptionException.class);
     }
-
-
 }


### PR DESCRIPTION
## 관련 IssueNumber

#112 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 회원가입 절차를 아직 마치지 않은 유저에 대한 ArgumentResolver 를 구현했습니다. 