### PR TITLE
[refactor] 테스트 격리 환경을 ApplicationContext 를 캐싱하고, 계층별 슬라이스 테스트를 적용하여 빌드 속도 최적화 

### DIFF
--- a/backend/src/main/java/moheng/auth/application/AuthService.java
+++ b/backend/src/main/java/moheng/auth/application/AuthService.java
@@ -18,8 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service
-public class
-AuthService {
+public class AuthService {
     private final OAuthProvider oAuthProvider;
     private final MemberService memberService;
     private final TokenManager tokenManager;

--- a/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationBearerExtractor.java
+++ b/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationBearerExtractor.java
@@ -12,6 +12,9 @@ import java.util.Objects;
 public class AuthenticationBearerExtractor {
     private static final String BEARER_TYPE = "Bearer ";
 
+    private AuthenticationBearerExtractor() {
+    }
+
     public String extract(final HttpServletRequest httpServletRequest) {
         String authorizationHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
 

--- a/backend/src/main/java/moheng/keyword/domain/Keyword.java
+++ b/backend/src/main/java/moheng/keyword/domain/Keyword.java
@@ -32,6 +32,10 @@ public class Keyword extends BaseEntity {
         }
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getName() {
         return name;
     }

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
     }
 
     @PostMapping("/signup/trip")
-    public ResponseEntity<Void> signupInterestTrip(@Authentication final Accessor accessor,
+    public ResponseEntity<Void> signupInterestTrip(@InitAuthentication final Accessor accessor,
                                                     @RequestBody final SignUpInterestTripsRequest signUpInterestTripsRequest) {
         memberService.signUpByInterestTrips(accessor.getId(), signUpInterestTripsRequest);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/moheng/recommendtrip/domain/RecommendTrip.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/RecommendTrip.java
@@ -42,6 +42,10 @@ public class RecommendTrip extends BaseEntity {
         this.rank = 1L;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public Long getRank() {
         return rank;
     }

--- a/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
@@ -22,6 +22,7 @@ public interface RecommendTripRepository extends JpaRepository<RecommendTrip, Lo
 
     boolean existsByMemberAndTrip(final Member member, final Trip trip);
 
+    @Transactional
     void deleteByMemberAndRank(final Member member, final long rank);
 
     boolean existsByMemberAndRank(final Member member, final long rank);

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -26,6 +26,7 @@ public class TripService {
     private static final long HIGHEST_PRIORITY_RANK = 1L;
     private static final long LOWEST_PRIORITY_RANK = 10L;
     private final ExternalSimilarTripModelClient externalSimilarTripModelClient;
+
     private final TripRepository tripRepository;
     private final RecommendTripRepository recommendTripRepository;
     private final MemberRepository memberRepository;

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -8,8 +8,8 @@ import moheng.member.exception.NoExistMemberException;
 import moheng.recommendtrip.domain.RecommendTrip;
 import moheng.recommendtrip.domain.RecommendTripRepository;
 import moheng.trip.domain.*;
+import moheng.trip.domain.recommendstrategy.SaveRecommendTripStrategyProvider;
 import moheng.trip.dto.*;
-import moheng.trip.exception.InvalidRecommendTripRankException;
 import moheng.trip.exception.NoExistRecommendTripException;
 import moheng.trip.exception.NoExistTripException;
 import org.springframework.stereotype.Service;
@@ -26,7 +26,7 @@ public class TripService {
     private static final long HIGHEST_PRIORITY_RANK = 1L;
     private static final long LOWEST_PRIORITY_RANK = 10L;
     private final ExternalSimilarTripModelClient externalSimilarTripModelClient;
-
+    private final SaveRecommendTripStrategyProvider saveRecommendTripStrategyProvider;
     private final TripRepository tripRepository;
     private final RecommendTripRepository recommendTripRepository;
     private final MemberRepository memberRepository;
@@ -37,13 +37,15 @@ public class TripService {
                        final ExternalSimilarTripModelClient externalSimilarTripModelClient,
                        final RecommendTripRepository recommendTripRepository,
                        final MemberRepository memberRepository,
-                       final MemberTripRepository memberTripRepository, TripKeywordRepository tripKeywordRepository) {
+                       final MemberTripRepository memberTripRepository, TripKeywordRepository tripKeywordRepository,
+                       final SaveRecommendTripStrategyProvider saveRecommendTripStrategyProvider) {
         this.tripRepository = tripRepository;
         this.externalSimilarTripModelClient = externalSimilarTripModelClient;
         this.recommendTripRepository = recommendTripRepository;
         this.memberRepository = memberRepository;
         this.memberTripRepository = memberTripRepository;
         this.tripKeywordRepository = tripKeywordRepository;
+        this.saveRecommendTripStrategyProvider = saveRecommendTripStrategyProvider;
     }
 
     @Transactional

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -1,0 +1,33 @@
+package moheng.trip.domain.recommendstrategy;
+
+import moheng.member.domain.Member;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.recommendtrip.domain.RecommendTripRepository;
+import moheng.trip.domain.Trip;
+import moheng.trip.exception.NoExistRecommendTripException;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+public class AppendRecommendTripStrategy implements RecommendTripStrategy {
+    private final RecommendTripRepository recommendTripRepository;
+
+    public AppendRecommendTripStrategy(final RecommendTripRepository recommendTripRepository) {
+        this.recommendTripRepository = recommendTripRepository;
+    }
+
+    @Override
+    public void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips) {
+        long highestRank = findHighestRecommendTripRank(recommendTrips);
+        recommendTripRepository.save(new RecommendTrip(trip, member, highestRank + 1));
+    }
+
+    private long findHighestRecommendTripRank(final List<RecommendTrip> recommendTrips) {
+        return recommendTrips.stream()
+                .max(Comparator.comparing(RecommendTrip::getRank))
+                .map(RecommendTrip::getRank)
+                .orElseThrow(() -> new NoExistRecommendTripException("선호 여행지 정보가 없습니다."));
+    }
+}

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -20,7 +20,7 @@ public class AppendRecommendTripStrategy implements RecommendTripStrategy {
 
     @Override
     public void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips) {
-        long highestRank = findHighestRecommendTripRank(recommendTrips);
+        final long highestRank = findHighestRecommendTripRank(recommendTrips);
         recommendTripRepository.save(new RecommendTrip(trip, member, highestRank + 1));
     }
 

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -30,4 +30,9 @@ public class AppendRecommendTripStrategy implements RecommendTripStrategy {
                 .map(RecommendTrip::getRank)
                 .orElseThrow(() -> new NoExistRecommendTripException("선호 여행지 정보가 없습니다."));
     }
+
+    @Override
+    public boolean isMatch(long recommendSize) {
+        return false;
+    }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -32,7 +32,7 @@ public class AppendRecommendTripStrategy implements RecommendTripStrategy {
     }
 
     @Override
-    public boolean isMatch(final long recommendSize, final long matchSize) {
-        return recommendSize < matchSize;
+    public boolean isMatch(final long recommendSize, final long maxSize) {
+        return recommendSize < maxSize;
     }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -32,7 +32,7 @@ public class AppendRecommendTripStrategy implements RecommendTripStrategy {
     }
 
     @Override
-    public boolean isMatch(long recommendSize) {
-        return false;
+    public boolean isMatch(final long recommendSize, final long matchSize) {
+        return recommendSize < matchSize;
     }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
@@ -7,5 +7,6 @@ import moheng.trip.domain.Trip;
 import java.util.List;
 
 public interface RecommendTripStrategy {
-    void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips);
+    void execute(final Trip trip, final Member member, final List<RecommendTrip> recommendTrips);
+    boolean isMatch(final long recommendSize);
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface RecommendTripStrategy {
     void execute(final Trip trip, final Member member, final List<RecommendTrip> recommendTrips);
-    boolean isMatch(final long recommendSize);
+    boolean isMatch(final long recommendSize, final long maxSize);
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/RecommendTripStrategy.java
@@ -1,0 +1,11 @@
+package moheng.trip.domain.recommendstrategy;
+
+import moheng.member.domain.Member;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.trip.domain.Trip;
+
+import java.util.List;
+
+public interface RecommendTripStrategy {
+    void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips);
+}

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
@@ -1,0 +1,41 @@
+package moheng.trip.domain.recommendstrategy;
+
+import moheng.member.domain.Member;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.recommendtrip.domain.RecommendTripRepository;
+import moheng.trip.domain.Trip;
+import moheng.trip.exception.NoExistRecommendTripException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ReplaceRecommendTripStrategy implements RecommendTripStrategy {
+    private static final long LOWEST_PRIORITY_RANK = 10L;
+    private static final long HIGHEST_PRIORITY_RANK = 1L;
+    private final RecommendTripRepository recommendTripRepository;
+
+    public ReplaceRecommendTripStrategy(final RecommendTripRepository recommendTripRepository) {
+        this.recommendTripRepository = recommendTripRepository;
+    }
+
+    @Override
+    public void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips) {
+        if (!recommendTripRepository.existsByMemberAndTrip(member, trip)) {
+            downAllRanks(recommendTrips);
+            deleteHighestPriorityRankRecommendTrip(member);
+            recommendTripRepository.save(new RecommendTrip(trip, member, LOWEST_PRIORITY_RANK));
+        }
+    }
+
+    private void deleteHighestPriorityRankRecommendTrip(final Member member) {
+        if(!recommendTripRepository.existsByMemberAndRank(member, HIGHEST_PRIORITY_RANK - 1)) {
+            throw new NoExistRecommendTripException("존재하지 않는 선호 여행지 정보입니다.");
+        }
+        recommendTripRepository.deleteByMemberAndRank(member, HIGHEST_PRIORITY_RANK - 1);
+    }
+
+    private void downAllRanks(List<RecommendTrip> recommendTrips) {
+        recommendTripRepository.bulkDownRank(recommendTrips);
+    }
+}

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
@@ -38,4 +38,9 @@ public class ReplaceRecommendTripStrategy implements RecommendTripStrategy {
     private void downAllRanks(List<RecommendTrip> recommendTrips) {
         recommendTripRepository.bulkDownRank(recommendTrips);
     }
+
+    @Override
+    public boolean isMatch(long recommendSize) {
+        return false;
+    }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/ReplaceRecommendTripStrategy.java
@@ -20,7 +20,7 @@ public class ReplaceRecommendTripStrategy implements RecommendTripStrategy {
     }
 
     @Override
-    public void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips) {
+    public void execute(final Trip trip, final Member member, final List<RecommendTrip> recommendTrips) {
         if (!recommendTripRepository.existsByMemberAndTrip(member, trip)) {
             downAllRanks(recommendTrips);
             deleteHighestPriorityRankRecommendTrip(member);
@@ -35,12 +35,12 @@ public class ReplaceRecommendTripStrategy implements RecommendTripStrategy {
         recommendTripRepository.deleteByMemberAndRank(member, HIGHEST_PRIORITY_RANK - 1);
     }
 
-    private void downAllRanks(List<RecommendTrip> recommendTrips) {
+    private void downAllRanks(final List<RecommendTrip> recommendTrips) {
         recommendTripRepository.bulkDownRank(recommendTrips);
     }
 
     @Override
-    public boolean isMatch(long recommendSize) {
-        return false;
+    public boolean isMatch(final long recommendSize, final long maxSize) {
+        return recommendSize >= maxSize;
     }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
@@ -1,4 +1,22 @@
 package moheng.trip.domain.recommendstrategy;
 
+import moheng.trip.exception.NoExistRecommendTripStrategyException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
 public class SaveRecommendTripStrategyProvider {
+    private final List<RecommendTripStrategy> recommendTripStrategies;
+
+    public SaveRecommendTripStrategyProvider(final List<RecommendTripStrategy> recommendTripStrategies) {
+        this.recommendTripStrategies = recommendTripStrategies;
+    }
+
+    public RecommendTripStrategy findRecommendTripStrategy(final long recommendSize) {
+        return recommendTripStrategies.stream()
+                .filter(recommendTripStrategy -> recommendTripStrategy.isMatch(recommendSize))
+                .findFirst()
+                .orElseThrow(NoExistRecommendTripStrategyException::new);
+    }
 }

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
@@ -1,0 +1,4 @@
+package moheng.trip.domain.recommendstrategy;
+
+public class SaveRecommendTripStrategyProvider {
+}

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/SaveRecommendTripStrategyProvider.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Component
 public class SaveRecommendTripStrategyProvider {
+    private static final long MAX_SAVE_RECOMMEND_TRIPS_SIZE = 10L;
     private final List<RecommendTripStrategy> recommendTripStrategies;
 
     public SaveRecommendTripStrategyProvider(final List<RecommendTripStrategy> recommendTripStrategies) {
@@ -15,7 +16,7 @@ public class SaveRecommendTripStrategyProvider {
 
     public RecommendTripStrategy findRecommendTripStrategy(final long recommendSize) {
         return recommendTripStrategies.stream()
-                .filter(recommendTripStrategy -> recommendTripStrategy.isMatch(recommendSize))
+                .filter(recommendTripStrategy -> recommendTripStrategy.isMatch(recommendSize, MAX_SAVE_RECOMMEND_TRIPS_SIZE))
                 .findFirst()
                 .orElseThrow(NoExistRecommendTripStrategyException::new);
     }

--- a/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripStrategyException.java
+++ b/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripStrategyException.java
@@ -1,0 +1,11 @@
+package moheng.trip.exception;
+
+public class NoExistRecommendTripStrategyException extends RuntimeException {
+    public NoExistRecommendTripStrategyException(String message) {
+        super(message);
+    }
+
+    public NoExistRecommendTripStrategyException() {
+        super("제공되지 않는 선호 여행지 저장 전략입니다.");
+    }
+}

--- a/backend/src/test/java/moheng/acceptance/config/AcceptanceTestConfig.java
+++ b/backend/src/test/java/moheng/acceptance/config/AcceptanceTestConfig.java
@@ -7,9 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
 public abstract class AcceptanceTestConfig {
     @LocalServerPort
     private int port;

--- a/backend/src/test/java/moheng/acceptance/config/AcceptanceTestConfig.java
+++ b/backend/src/test/java/moheng/acceptance/config/AcceptanceTestConfig.java
@@ -1,6 +1,7 @@
 package moheng.acceptance.config;
 
 import io.restassured.RestAssured;
+import moheng.config.DatabaseCleaner;
 import moheng.config.TestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +16,12 @@ public abstract class AcceptanceTestConfig {
     @LocalServerPort
     private int port;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        databaseCleaner.clear();
     }
 }

--- a/backend/src/test/java/moheng/auth/presentation/AuthenticationBearerExtractorTest.java
+++ b/backend/src/test/java/moheng/auth/presentation/AuthenticationBearerExtractorTest.java
@@ -5,13 +5,28 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
+import jakarta.servlet.http.HttpServletRequest;
 import moheng.auth.exception.EmptyBearerHeaderException;
 import moheng.auth.exception.InvalidTokenFormatException;
+import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
+import moheng.config.TestConfig;
 import moheng.config.slice.ControllerTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
-public class AuthenticationBearerExtractorTest extends ControllerTestConfig {
+@SpringBootTest
+@ActiveProfiles("test")
+public class AuthenticationBearerExtractorTest {
+    @Autowired
+    private AuthenticationBearerExtractor authenticationBearerExtractor;
+
+    @MockBean
+    protected HttpServletRequest httpServletRequest;
 
     @DisplayName("헤더의 Authorization 값이 비어있으면 예외가 발생한다.")
     @Test

--- a/backend/src/test/java/moheng/config/DatabaseCleaner.java
+++ b/backend/src/test/java/moheng/config/DatabaseCleaner.java
@@ -1,0 +1,39 @@
+package moheng.config;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.Type;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DatabaseCleaner {
+    private EntityManager entityManager;
+    private List<String> tableNames;
+
+    public DatabaseCleaner(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+        this.tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .map(Type::getJavaType)
+                .map(javaType -> javaType.getAnnotation(Table.class))
+                .map(Table::name)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
+    }
+}

--- a/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
@@ -4,31 +4,48 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import moheng.auth.application.AuthService;
 import moheng.auth.domain.token.JwtTokenProvider;
+import moheng.auth.presentation.AuthController;
 import moheng.auth.presentation.authentication.AuthenticationArgumentResolver;
 import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
 import moheng.config.TestConfig;
 import moheng.keyword.application.KeywordService;
+import moheng.keyword.presentation.KeywordController;
 import moheng.liveinformation.application.LiveInformationService;
 import moheng.liveinformation.application.MemberLiveInformationService;
+import moheng.liveinformation.presentation.LiveInformationController;
+import moheng.liveinformation.presentation.MemberLiveInformationController;
 import moheng.member.application.MemberService;
 import moheng.member.domain.repository.MemberRepository;
+import moheng.member.presentation.MemberController;
 import moheng.recommendtrip.application.RecommendTripService;
+import moheng.recommendtrip.presentation.RecommendTripController;
 import moheng.trip.application.TripService;
+import moheng.trip.presentation.TripController;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureRestDocs
-@SpringBootTest(classes = TestConfig.class)
+@WebMvcTest({
+        AuthController.class,
+        KeywordController.class,
+        LiveInformationController.class,
+        MemberLiveInformationController.class,
+        MemberController.class,
+        RecommendTripController.class,
+        TripController.class
+})
+@Import(TestConfig.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public abstract class ControllerTestConfig {
     @Autowired
     protected MockMvc mockMvc;

--- a/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
@@ -44,7 +44,6 @@ import org.springframework.test.web.servlet.MockMvc;
         TripController.class
 })
 @Import(TestConfig.class)
-@AutoConfigureMockMvc
 @ActiveProfiles("test")
 public abstract class ControllerTestConfig {
     @Autowired
@@ -62,13 +61,10 @@ public abstract class ControllerTestConfig {
     @MockBean
     protected MemberService memberService;
 
-    @Autowired
-    protected AuthenticationArgumentResolver authenticationArgumentResolver;
-
-    @Autowired
+    @MockBean
     protected AuthenticationBearerExtractor authenticationBearerExtractor;
 
-    @Mock
+    @MockBean
     protected HttpServletRequest httpServletRequest;
 
     @MockBean

--- a/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/ControllerTestConfig.java
@@ -7,6 +7,7 @@ import moheng.auth.domain.token.JwtTokenProvider;
 import moheng.auth.presentation.AuthController;
 import moheng.auth.presentation.authentication.AuthenticationArgumentResolver;
 import moheng.auth.presentation.authentication.AuthenticationBearerExtractor;
+import moheng.auth.presentation.initauthentication.InitAuthenticationArgumentResolver;
 import moheng.config.TestConfig;
 import moheng.keyword.application.KeywordService;
 import moheng.keyword.presentation.KeywordController;
@@ -63,9 +64,6 @@ public abstract class ControllerTestConfig {
 
     @MockBean
     protected AuthenticationBearerExtractor authenticationBearerExtractor;
-
-    @MockBean
-    protected HttpServletRequest httpServletRequest;
 
     @MockBean
     protected LiveInformationService liveInformationService;

--- a/backend/src/test/java/moheng/config/slice/RepositoryTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/RepositoryTestConfig.java
@@ -2,14 +2,14 @@ package moheng.config.slice;
 
 import moheng.config.TestConfig;
 import moheng.global.config.JpaAuditConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DataJpaTest
 @Import(JpaAuditConfig.class)
 @ActiveProfiles("test")
-@SpringBootTest(classes = TestConfig.class)
 public abstract class RepositoryTestConfig {
 }

--- a/backend/src/test/java/moheng/config/slice/ServiceTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/ServiceTestConfig.java
@@ -9,7 +9,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = TestConfig.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 public abstract class ServiceTestConfig {
     @Autowired

--- a/backend/src/test/java/moheng/config/slice/ServiceTestConfig.java
+++ b/backend/src/test/java/moheng/config/slice/ServiceTestConfig.java
@@ -1,6 +1,7 @@
 package moheng.config.slice;
 
 import moheng.auth.domain.token.RefreshTokenRepository;
+import moheng.config.DatabaseCleaner;
 import moheng.config.TestConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +15,12 @@ public abstract class ServiceTestConfig {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @BeforeEach
     public void setUp() {
         refreshTokenRepository.deleteAll();
+        databaseCleaner.clear();
     }
 }

--- a/backend/src/test/java/moheng/keyword/domain/KeywordRepositoryTest.java
+++ b/backend/src/test/java/moheng/keyword/domain/KeywordRepositoryTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-@SpringBootTest(classes = TestConfig.class)
+
 public class KeywordRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private KeywordRepository keywordRepository;

--- a/backend/src/test/java/moheng/keyword/domain/TripKeywordRepositoryTest.java
+++ b/backend/src/test/java/moheng/keyword/domain/TripKeywordRepositoryTest.java
@@ -28,16 +28,19 @@ public class TripKeywordRepositoryTest extends RepositoryTestConfig {
     @DisplayName("키워드에 해당하는 여행지 키워드들을 찾는다.")
     @Test
     void 키워드에_해당하는_여행지_키워드들을_찾는다 () {
-        tripRepository.save(new Trip("여행", "장소", 1L, "설명", "이미지"));
-        keywordRepository.save(new Keyword("키워드1")); keywordRepository.save(new Keyword("키워드2"));
+        // Save the trip and keywords
+        Trip savedTrip = tripRepository.save(new Trip("여행", "장소", 1L, "설명", "이미지"));
+        Keyword savedKeyword1 = keywordRepository.save(new Keyword("키워드1"));
+        Keyword savedKeyword2 = keywordRepository.save(new Keyword("키워드2"));
 
-        Trip trip = tripRepository.findById(1L).get();
-        Keyword keyword1 = keywordRepository.findById(1L).get();
-        Keyword keyword2 = keywordRepository.findById(2L).get();
+        Trip trip = tripRepository.findById(savedTrip.getId()).orElseThrow(() -> new IllegalStateException("Trip not found"));
+        Keyword keyword1 = keywordRepository.findById(savedKeyword1.getId()).orElseThrow(() -> new IllegalStateException("Keyword1 not found"));
+        Keyword keyword2 = keywordRepository.findById(savedKeyword2.getId()).orElseThrow(() -> new IllegalStateException("Keyword2 not found"));
 
         tripKeywordRepository.save(new TripKeyword(trip, keyword1));
         tripKeywordRepository.save(new TripKeyword(trip, keyword2));
 
-        assertThat(tripKeywordRepository.findTripKeywordsByKeywordIds(List.of(1L, 2L)).size()).isEqualTo(2);
+        assertThat(tripKeywordRepository.findTripKeywordsByKeywordIds(List.of(keyword1.getId(), keyword2.getId())).size()).isEqualTo(2);
     }
+
 }

--- a/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.ArrayList;
 import java.util.List;
 
-@SpringBootTest(classes = TestConfig.class)
 public class MemberLiveInformationRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private MemberLiveInformationRepository memberLiveInformationRepository;

--- a/backend/src/test/java/moheng/member/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/moheng/member/domain/MemberRepositoryTest.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 
-
 public class MemberRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private MemberRepository memberRepository;

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -64,7 +64,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 프로필_정보로_회원가입에_성공하면_상태코드_204을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
         mockMvc.perform(post("/member/signup/profile")
@@ -95,7 +95,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 중복되는_닉네임_없이_사용_가능한_닉네임이라면_메시지와_상태코드_200을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
         mockMvc.perform(post("/member/check/nickname")
@@ -125,7 +125,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 중복되는_닉네임이_존재한다면_상태코드_401을_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
         doThrow(new DuplicateNicknameException("중복되는 닉네임이 존재합니다."))
                 .when(memberService).checkIsAlreadyExistNickname(anyString());
 
@@ -217,7 +217,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 여행지_추천에_필요한_생활정보를_입력하여_회원가입에_성공하면_상태코드_204를_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(하온_신규()));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
         doNothing().when(memberService).signUpByLiveInfo(anyLong(), any());
 
         // when, then
@@ -272,6 +272,7 @@ public class MemberControllerTest extends ControllerTestConfig {
     void 관심_여행지를_선택하여_회원가입에_성공했다면_상태코드_204를_리턴한다() throws Exception {
         // given
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
         mockMvc.perform(post("/member/signup/trip")

--- a/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
+++ b/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
@@ -19,7 +19,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-@SpringBootTest(classes = TestConfig.class)
 public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private RecommendTripRepository recommendTripRepository;

--- a/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
+++ b/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
@@ -10,8 +10,10 @@ import moheng.config.TestConfig;
 import moheng.keyword.dto.RecommendTripResponse;
 import moheng.member.application.MemberService;
 import moheng.member.domain.Member;
+import moheng.member.domain.repository.MemberRepository;
 import moheng.trip.application.TripService;
 import moheng.trip.domain.Trip;
+import moheng.trip.domain.TripRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,19 +26,19 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     private RecommendTripRepository recommendTripRepository;
 
     @Autowired
-    private MemberService memberService;
+    private MemberRepository memberRepository;
 
     @Autowired
-    private TripService tripService;
+    private TripRepository tripRepository;
 
     @DisplayName("멤버의 선호 여행지 contentId 와 방문횟수를 찾는다.")
     @Test
     void 멤버의_선호_여행지_contentId_와_방문횟수를_찾는다() {
         // given
-        memberService.save(하온_기존());
-        Member member = memberService.findByEmail(하온_이메일);
-        tripService.save(new Trip("여행지", "장소명", 1L, "설명", "이미지 경로"));
-        Trip trip = tripService.findByContentId(1L);
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).orElseThrow();
+        tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지 경로"));
+        Trip trip = tripRepository.findByContentId(1L).get();
         recommendTripRepository.save(new RecommendTrip(trip, member));
 
         // when
@@ -50,11 +52,11 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     @Test
     void 멤버의_선호_여행지를_찾는다() {
         // given
-        memberService.save(하온_기존());
-        Member member = memberService.findByEmail(하온_이메일);
-        tripService.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
-        tripService.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
-        Trip trip = tripService.findByContentId(1L);
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).orElseThrow();
+        tripRepository.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
+        tripRepository.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
+        Trip trip = tripRepository.findByContentId(1L).get();
         recommendTripRepository.save(new RecommendTrip(trip, member));
         recommendTripRepository.save(new RecommendTrip(trip, member));
 
@@ -66,11 +68,11 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     @Test
     void 멤버의_최대_10개_선호_여행지를_찾는다() {
         // given
-        memberService.save(하온_기존());
-        Member member = memberService.findByEmail(하온_이메일);
-        tripService.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
-        tripService.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
-        Trip trip = tripService.findByContentId(1L);
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).orElseThrow();
+        tripRepository.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
+        tripRepository.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
+        Trip trip = tripRepository.findByContentId(1L).get();
         recommendTripRepository.save(new RecommendTrip(trip, member));
         recommendTripRepository.save(new RecommendTrip(trip, member));
 
@@ -82,17 +84,23 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     @Test
     void 모든_선호_여행지의_rank_를_1씩_감소시킨다() {
         // given
-        memberService.save(하온_기존());
-        Member member = memberService.findByEmail(하온_이메일);
-        tripService.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
-        tripService.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
-        tripService.save(new Trip("여행지3", "장소명2", 3L, "설명3", "이미지 경로"));
-        tripService.save(new Trip("여행지4", "장소명2", 4L, "설명4", "이미지 경로"));
-        Trip trip1 = tripService.findByContentId(1L); Trip trip2 = tripService.findByContentId(2L);
-        Trip trip3 = tripService.findByContentId(3L); Trip trip4 = tripService.findByContentId(4L);
+        memberRepository.save(하온_기존());
+        Member member = memberRepository.findByEmail(하온_이메일).orElseThrow();
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        tripRepository.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로"));
+        tripRepository.save(new Trip("여행지2", "장소명2", 2L, "설명2", "이미지 경로"));
+        tripRepository.save(new Trip("여행지3", "장소명2", 3L, "설명3", "이미지 경로"));
+        tripRepository.save(new Trip("여행지4", "장소명2", 4L, "설명4", "이미지 경로"));
+
+        Trip trip1 = tripRepository.findByContentId(1L).orElseThrow();
+        Trip trip2 = tripRepository.findByContentId(2L).orElseThrow();
+        Trip trip3 = tripRepository.findByContentId(3L).orElseThrow();
+        Trip trip4 = tripRepository.findByContentId(4L).orElseThrow();
+
+        RecommendTrip recommendTrip1 = recommendTripRepository.save(new RecommendTrip(trip1, member, 1L));
+        RecommendTrip recommendTrip2 = recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        RecommendTrip recommendTrip3 = recommendTripRepository.save(new RecommendTrip(trip3, member, 3L));
+        RecommendTrip recommendTrip4 = recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
 
         // when
         List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
@@ -100,9 +108,11 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
 
         // then
         assertAll(() -> {
-            for(long id=1; id<=4; id++) {
-                assertThat(recommendTripRepository.findById(id).get().getRank()).isEqualTo(id-1);
-            }
+            assertThat(recommendTripRepository.findById(recommendTrip1.getId()).get().getRank()).isEqualTo(1L);
+            assertThat(recommendTripRepository.findById(recommendTrip2.getId()).get().getRank()).isEqualTo(2L);
+            assertThat(recommendTripRepository.findById(recommendTrip3.getId()).get().getRank()).isEqualTo(3L);
+            assertThat(recommendTripRepository.findById(recommendTrip4.getId()).get().getRank()).isEqualTo(4L);
         });
     }
+
 }

--- a/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
@@ -7,14 +7,17 @@ import moheng.recommendtrip.domain.RecommendTrip;
 import moheng.recommendtrip.domain.RecommendTripRepository;
 import moheng.trip.domain.Trip;
 import moheng.trip.domain.recommendstrategy.AppendRecommendTripStrategy;
+import moheng.trip.exception.NoExistRecommendTripException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static moheng.fixture.MemberFixtures.하온_기존;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
     private static final long MAX_SIZE = 10L;
@@ -77,5 +80,18 @@ public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
         long recommendSize = recommendTripRepository.findAllByMemberId(member.getId()).size();
 
         assertThat(appendRecommendTripStrategy.isMatch(recommendSize, MAX_SIZE)).isTrue();
+    }
+
+    @DisplayName("멤버의 선호 여행지가 비어있으면 선호 여행지 추가 전략에 예외가 발생한다.")
+    @Test
+    void 멤버의_선호_여행지가_비어있으면_선호_여행지_추가_전략에_예외가_발생한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L);
+
+        // when, then
+        assertThatThrownBy(() ->appendRecommendTripStrategy.execute(trip1, member, new ArrayList<>()))
+                .isInstanceOf(NoExistRecommendTripException.class);
     }
 }

--- a/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
@@ -1,0 +1,58 @@
+package moheng.trip.application;
+
+import moheng.config.slice.ServiceTestConfig;
+import moheng.member.domain.Member;
+import moheng.member.domain.repository.MemberRepository;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.recommendtrip.domain.RecommendTripRepository;
+import moheng.trip.domain.Trip;
+import moheng.trip.domain.recommendstrategy.AppendRecommendTripStrategy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static moheng.fixture.MemberFixtures.하온_기존;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
+    @Autowired
+    private AppendRecommendTripStrategy appendRecommendTripStrategy;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TripService tripService;
+
+    @Autowired
+    private RecommendTripRepository recommendTripRepository;
+
+    @DisplayName("선호 여행지 추가 전략ㅇㄴ 최근 클릭한 여행지가 10개 미만이라면 가장 높은 rank 에 1을 더한 선호 여행지 정보를 생성한다.")
+    @Test
+    public void 선호_여행지_추가_전략은_가장_높은_rank_에_1을_더한_선호_여행지_정보를_생성한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L);
+        Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L);
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L));
+
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
+
+        // when
+        Trip trip4 = tripService.findById(4L);
+        appendRecommendTripStrategy.execute(trip4, member, recommendTrips);
+
+        // then
+        RecommendTrip actual = recommendTripRepository.findById(trip4.getId()).get();
+        assertThat(actual.getRank()).isEqualTo(4L);
+    }
+}

--- a/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static moheng.fixture.MemberFixtures.하온_기존;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -58,7 +59,11 @@ public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
 
         // then
         RecommendTrip actual = recommendTripRepository.findById(trip4.getId()).get();
-        assertThat(actual.getRank()).isEqualTo(4L);
+
+        assertAll(() -> {
+            assertThat(recommendTripRepository.findAllByMemberId(member.getId()).size()).isEqualTo(4L);
+            assertThat(actual.getRank()).isEqualTo(4L);
+        });
     }
 
     @DisplayName("선호 여행지 추가 전략은 MAX SIZE 보다 작을 때 수행된다.")

--- a/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
@@ -66,7 +66,7 @@ public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
         });
     }
 
-    @DisplayName("선호 여행지 추가 전략은 MAX SIZE 보다 작을 때 수행된다.")
+    @DisplayName("선호 여행지 추가 전략은 현재 선호 여행지 개수가 MAX SIZE 보다 작을 때 수행된다.")
     @Test
     void 선호_여행지_추가_전략은_MAX_SIZE_보다_작을_때_수행된다() {
         // given

--- a/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/AppendRecommendTripStrategyTest.java
@@ -17,6 +17,8 @@ import static moheng.fixture.MemberFixtures.하온_기존;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
+    private static final long MAX_SIZE = 10L;
+
     @Autowired
     private AppendRecommendTripStrategy appendRecommendTripStrategy;
 
@@ -29,7 +31,7 @@ public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
     @Autowired
     private RecommendTripRepository recommendTripRepository;
 
-    @DisplayName("선호 여행지 추가 전략ㅇㄴ 최근 클릭한 여행지가 10개 미만이라면 가장 높은 rank 에 1을 더한 선호 여행지 정보를 생성한다.")
+    @DisplayName("선호 여행지 추가 전략은 최근 클릭한 여행지가 10개 미만이라면 가장 높은 rank 에 1을 더한 선호 여행지 정보를 생성한다.")
     @Test
     public void 선호_여행지_추가_전략은_가장_높은_rank_에_1을_더한_선호_여행지_정보를_생성한다() {
         // given
@@ -54,5 +56,26 @@ public class AppendRecommendTripStrategyTest extends ServiceTestConfig {
         // then
         RecommendTrip actual = recommendTripRepository.findById(trip4.getId()).get();
         assertThat(actual.getRank()).isEqualTo(4L);
+    }
+
+    @DisplayName("선호 여행지 추가 전략은 MAX SIZE 보다 작을 때 수행된다.")
+    @Test
+    void 선호_여행지_추가_전략은_MAX_SIZE_보다_작을_때_수행된다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L);
+        Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L);
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L));
+
+        long recommendSize = recommendTripRepository.findAllByMemberId(member.getId()).size();
+
+        assertThat(appendRecommendTripStrategy.isMatch(recommendSize, MAX_SIZE)).isTrue();
     }
 }

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -137,4 +137,43 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
         assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(trip.getId(), member.getId()))
                 .isInstanceOf(NoExistRecommendTripException.class);
     }
+
+    @DisplayName("교체 전략은 현재 방문한 여행지가 최근 클릭한 선호 여행지 리스트에 포함된다면 선호 여행지들의 랭크를 수정하지 않는다.")
+    @Test
+    void 교체_전략은_현재_방문한_여행지가_최근_클릭한_선호_여행지_리스트에_포함된다면_선호_여행지들의_랭크를_수정하지_않는다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
+        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
+        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
+        Trip trip9 = tripService.findById(9L);
+        Trip alreadyVisitedTrip = tripService.findById(10L);
+
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
+
+        // when
+        tripService.findWithSimilarOtherTrips(alreadyVisitedTrip.getId(), member.getId());
+
+        // then
+        assertAll(() -> {
+            for(long id=1; id<=10; id++) {
+                assertThat(recommendTripRepository.findById(id).get().getRank()).isEqualTo(id);
+            }
+        });
+    }
 }

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -1,0 +1,4 @@
+package moheng.trip.application;
+
+public class ReplaceRecommendTripStrategyTest {
+}

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -1,4 +1,67 @@
 package moheng.trip.application;
 
-public class ReplaceRecommendTripStrategyTest {
+import moheng.config.slice.ServiceTestConfig;
+import moheng.member.domain.Member;
+import moheng.member.domain.repository.MemberRepository;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.recommendtrip.domain.RecommendTripRepository;
+import moheng.trip.domain.Trip;
+import moheng.trip.domain.recommendstrategy.ReplaceRecommendTripStrategy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static moheng.fixture.MemberFixtures.하온_기존;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
+    @Autowired
+    private ReplaceRecommendTripStrategy replaceRecommendTripStrategy;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TripService tripService;
+
+    @Autowired
+    private RecommendTripRepository recommendTripRepository;
+
+    @DisplayName("기존의 rank 가 10인 선호 여행지를 제거하고 새로운 선호 여행지를 생성한다.")
+    @Test
+    void 기존의_rank_가_10인_선호_여행지를_제거하고_새로운_선호_여행지를_생성한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L);
+
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 10L));
+
+        // when
+        Trip trip = tripService.findById(10L);
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
+        replaceRecommendTripStrategy.execute(trip, member, recommendTrips);
+
+        // then
+        assertAll(() -> {
+            assertThat(recommendTripRepository.findById(11L).get().getRank()).isEqualTo(10L);
+        });
+    }
 }

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -30,7 +30,7 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
     @Autowired
     private RecommendTripRepository recommendTripRepository;
 
-    @DisplayName("기존의 rank 가 10인 선호 여행지를 제거하고 새로운 선호 여행지를 생성한다.")
+    @DisplayName("교체 전략은 기존의 rank 가 10인 선호 여행지를 제거하고 새로운 선호 여행지를 생성한다.")
     @Test
     void 기존의_rank_가_10인_선호_여행지를_제거하고_새로운_선호_여행지를_생성한다() {
         // given
@@ -58,6 +58,40 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
         Trip trip = tripService.findById(10L);
         List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
         replaceRecommendTripStrategy.execute(trip, member, recommendTrips);
+
+        // then
+        assertAll(() -> {
+            assertThat(recommendTripRepository.findById(11L).get().getRank()).isEqualTo(10L);
+        });
+    }
+
+    @DisplayName("교체 전략은 최근 클릭한 여행지가 10개라면 기존의 rank를 1씩 감소시키고, rank가 10인 새로운 선호 여행지를 생성한다.")
+    @Test
+    void 교체_전략은_최근_클릭한_여행지가_10개라면_기존의_rank를_1씩_감소시키고_rank가_10인_새로운_선호_여행지를_생성한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L);
+
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 10L));
+
+        // when
+        Trip trip = tripService.findById(10L);
+        tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
 
         // then
         assertAll(() -> {

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
+    private static final long MAX_SIZE = 10L;
+
     @Autowired
     private ReplaceRecommendTripStrategy replaceRecommendTripStrategy;
 
@@ -175,5 +177,38 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
                 assertThat(recommendTripRepository.findById(id).get().getRank()).isEqualTo(id);
             }
         });
+    }
+
+    @DisplayName("교체 전략은 현재 선호 여행지 개수가 MAX SIZE 와 같을 때 수행된다.")
+    @Test
+    void 교체_전략은_현재_선호_여행지_개수가_MAX_SIZE_와_같을_때_수행된다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
+        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
+        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
+        Trip trip9 = tripService.findById(9L);
+        Trip alreadyVisitedTrip = tripService.findById(10L);
+
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
+
+        long recommendSize = recommendTripRepository.findAllByMemberId(member.getId()).size();
+
+        assertThat(replaceRecommendTripStrategy.isMatch(recommendSize, MAX_SIZE)).isTrue();
     }
 }

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -95,7 +95,8 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
 
         // when
         Trip trip = tripService.findById(10L);
-        tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
+        replaceRecommendTripStrategy.execute(trip, member, recommendTrips);
 
         // then
         assertAll(() -> {
@@ -134,9 +135,10 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
 
         // when
         Trip trip = tripService.findById(11L);
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
 
         // then
-        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(trip.getId(), member.getId()))
+        assertThatThrownBy(() -> replaceRecommendTripStrategy.execute(trip, member, recommendTrips))
                 .isInstanceOf(NoExistRecommendTripException.class);
     }
 
@@ -169,7 +171,8 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
         recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
 
         // when
-        tripService.findWithSimilarOtherTrips(alreadyVisitedTrip.getId(), member.getId());
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
+        replaceRecommendTripStrategy.execute(alreadyVisitedTrip, member, recommendTrips);
 
         // then
         assertAll(() -> {
@@ -177,6 +180,42 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
                 assertThat(recommendTripRepository.findById(id).get().getRank()).isEqualTo(id);
             }
         });
+    }
+
+    @DisplayName("교체 전략은 가장 높은 우선순위 rank 값을 가진 선호 여행지가 없다면 예외가 발생한다")
+    @Test
+    void 교체_전략은_가장_높은_우선순위_rank_값을_가진_선호_여행지가_없다면_예외가_발생한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
+        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
+        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
+        Trip trip9 = tripService.findById(9L);
+        Trip alreadyVisitedTrip = tripService.findById(10L);
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 11L));
+
+        List<RecommendTrip> recommendTrips = recommendTripRepository.findAllByMemberId(member.getId());
+
+        // when, then
+        assertThatThrownBy(() -> replaceRecommendTripStrategy.execute(trip1, member, recommendTrips))
+                .isInstanceOf(NoExistRecommendTripException.class);
     }
 
     @DisplayName("교체 전략은 현재 선호 여행지 개수가 MAX SIZE 와 같을 때 수행된다.")

--- a/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
+++ b/backend/src/test/java/moheng/trip/application/ReplaceRecommendTripStrategyTest.java
@@ -7,6 +7,7 @@ import moheng.recommendtrip.domain.RecommendTrip;
 import moheng.recommendtrip.domain.RecommendTripRepository;
 import moheng.trip.domain.Trip;
 import moheng.trip.domain.recommendstrategy.ReplaceRecommendTripStrategy;
+import moheng.trip.exception.NoExistRecommendTripException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static moheng.fixture.MemberFixtures.하온_기존;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
@@ -97,5 +99,42 @@ public class ReplaceRecommendTripStrategyTest extends ServiceTestConfig {
         assertAll(() -> {
             assertThat(recommendTripRepository.findById(11L).get().getRank()).isEqualTo(10L);
         });
+    }
+
+    @DisplayName("교체 전략은 기존에 rank가 1등인 선호 여행지가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void 교체_전략은_기존에_rank가_1등인_선호_여행지가_존재하지_않으면_예외가_발생한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        tripService.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
+        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
+        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
+        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
+        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
+        Trip trip11 = tripService.findById(11L);
+
+        recommendTripRepository.save(new RecommendTrip(trip1, member, 0L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+
+        // when
+        Trip trip = tripService.findById(11L);
+
+        // then
+        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(trip.getId(), member.getId()))
+                .isInstanceOf(NoExistRecommendTripException.class);
     }
 }

--- a/backend/src/test/java/moheng/trip/domain/MemberTripRepositoryTest.java
+++ b/backend/src/test/java/moheng/trip/domain/MemberTripRepositoryTest.java
@@ -24,33 +24,36 @@ public class MemberTripRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private TripRepository tripRepository;
 
-    @DisplayName("멤버의 여행지가 존재하면 참을 리턴한다.")
-    @Test
-    void 멤버의_여행지가_존재하면_참을_리턴한다() {
-        // given
-        memberRepository.save(하온_기존());
-        tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지"));
-        Member member = memberRepository.findById(1L).get();
-        Trip trip = tripRepository.findById(1L).get();
-
-        memberTripRepository.save(new MemberTrip(member, trip));
-
-        // when, then
-        assertTrue(() -> memberTripRepository.existsByMemberAndTrip(member, trip));
-    }
-
     @DisplayName("멤버의 여행지를 찾는다.")
     @Test
     void 멤버의_여행지를_찾는다() {
         // given
-        memberRepository.save(하온_기존());
-        tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지"));
-        Member member = memberRepository.findById(1L).get();
-        Trip trip = tripRepository.findById(1L).get();
+        Member savedMember = memberRepository.save(하온_기존());
+        Trip savedTrip = tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지"));
+
+        Member member = memberRepository.findById(savedMember.getId()).orElseThrow(() -> new IllegalStateException("Member not found"));
+        Trip trip = tripRepository.findById(savedTrip.getId()).orElseThrow(() -> new IllegalStateException("Trip not found"));
 
         memberTripRepository.save(new MemberTrip(member, trip));
 
         // when, then
         assertDoesNotThrow(() -> memberTripRepository.findByMemberAndTrip(member, trip));
     }
+
+    @DisplayName("멤버의 여행지가 존재하면 참을 리턴한다.")
+    @Test
+    void 멤버의_여행지가_존재하면_참을_리턴한다() {
+        // given
+        Member savedMember = memberRepository.save(하온_기존());
+        Trip savedTrip = tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지"));
+
+        Member member = memberRepository.findById(savedMember.getId()).orElseThrow(() -> new IllegalStateException("Member not found"));
+        Trip trip = tripRepository.findById(savedTrip.getId()).orElseThrow(() -> new IllegalStateException("Trip not found"));
+
+        memberTripRepository.save(new MemberTrip(member, trip));
+
+        // when, then
+        assertTrue(memberTripRepository.existsByMemberAndTrip(member, trip));
+    }
+
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: test
   datasource:
     url: jdbc:h2:mem:~/moheng;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE
     username: sa


### PR DESCRIPTION
## 관련 IssueNumber

#129 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 현재 DirtiesContext 로 테스트 환경 격리 환경을 구축하고 있는데, 이는 ApplicationContext 를 캐싱하지 못한다는 단점으로 인해 빌드 속도가 매우 오래걸립니다. DirtiesContext 를  제거하고, 빌드 속도를 최적화했습니다. 

### 상세 작업내용

1.  `DirtiesContext` 제거
2. `DataBaseCleaner` 생성 : TRUNCATE 로 테이블 안의 모든 데이터를 초기화(삭제)
3. `슬라이스 테스트(Slice Test)` 기법으로 개선
   3-1. 프레젠테이션 계층 테스트 최적화 : @MockBean 통합, https://github.com/SpringBootTest 를 @WebMvcTest 로 마이그레이션
   3-2.  레포지토리 계층 테스트 최적화 : @DataJpaTest 로 마이그레이션

## 테스트 및 결과

기존에 로컬 테스트 환경 기준 약 56초 가량 걸리던 테스트 빌드를, 리팩토링 결과 현재 약 3초로 크게 개선했습니다. 

## 관련 스크린샷 및 참고자료 (Optional)


#### 기존 실행

![image](https://github.com/user-attachments/assets/27791f87-5461-42e1-912a-c900735eadbf)

#### 최적화 결과

![image](https://github.com/user-attachments/assets/ce1c1889-d0be-4750-8f6f-9805776adc4f)

