### PR TITLE
[feat] 로그인 여부에 따라 세가지 상황으로 헤더 구성 변경

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -30,7 +30,7 @@
     margin-right: 10px;
 }
 
-.profile-img {
+.header-profile {
     height: 55px !important;
     width: 55px !important;
     cursor: pointer;

--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -4,6 +4,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    padding: 10px 20px;
 }
 
 .moheng {
@@ -11,11 +12,53 @@
 }
 
 .logo-img {
-    height:70px;
-    width: 100px
+    height: 70px;
+    width: 100px;
 }
 
 .login {
     margin-left: auto;
     margin-right: 20px;
+    font-size: x-large;
+    color: white;
+    text-decoration: none;
+}
+
+.profile-menu {
+    position: relative;
+    margin-left: auto;
+    margin-right: 10px;
+}
+
+.profile-img {
+    height: 55px !important;
+    width: 55px !important;
+    cursor: pointer;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    right: 0;
+    background-color: #f9f9f9;
+    min-width: 160px;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.profile-menu:hover .dropdown-content {
+    display: block;
+}
+
+.dropdown-content a,
+.logout-menu-item {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+}
+
+.dropdown-content a:hover,
+.logout-menu-item:hover {
+    background-color: #e0e0e0;
 }

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -1,19 +1,55 @@
-import logo from '../../assets/logo.png'
-import "./Header.css"
-import {Link} from 'react-router-dom'
+import React, { useState, useEffect } from 'react';
+import logo from '../../assets/logo.png';
+import "./Header.css";
+import { Link } from 'react-router-dom';
+import profileimg1 from "../../assets/profileimg1.png" //예시로 넣어 볼 프로필 이미지
 
 const Header = () => {
+  // 로그인 상태와 사용자 정보를 관리할 상태 변수
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isFirstLogin, setIsFirstLogin] = useState(true); // 최초 로그인 여부
+  const [profileImg, setProfileImg] = useState(null); // 프로필 이미지 경로
+
+  useEffect(() => {
+    // 1: 로그인 전
+    setIsLoggedIn(false);
+    setIsFirstLogin(true);
+
+    // 2: 최초 로그인 (회원가입 후 프로필 설정 단계) /signup/profile , /signup/livinginfo, /signup/interestedplace 페이지에서의 헤더
+    // setIsLoggedIn(true);
+    // setIsFirstLogin(true);
+
+    // 3: 로그인 후 (프로필 설정 완료)
+    // setIsLoggedIn(true);
+    // setIsFirstLogin(false);
+    // setProfileImg(profileimg1);
+  }, []); // 빈 배열을 넣어 useEffect가 컴포넌트 마운트 시 한 번만 실행되도록 함
+
   return (
     <section className='header'>
-      <Link to ='/'>
+      <Link to='/'>
         <img src={logo} className='logo-img' />
       </Link>
       <div className='moheng'>모행</div>
 
-      <div className='login'>로그인</div>
-
+      {isLoggedIn ? (
+        isFirstLogin ? null : (
+          <div className="profile-menu">
+            <img src={profileImg} className='profile-img' alt="Profile" />
+            <div className="dropdown-content">
+              <Link to="/mypage">마이페이지</Link>
+              <Link to="/planner">플래너</Link>
+              <div className="logout-menu-item">로그아웃</div>
+            </div>
+          </div>
+        )
+      ) : (
+        <Link to='/login' className='login'>
+          로그인
+        </Link>
+      )}
     </section>
   );
 };
-  
+
 export default Header;

--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import logo from '../../assets/logo.png';
 import "./Header.css";
 import { Link } from 'react-router-dom';
-import profileimg1 from "../../assets/profileimg1.png" //예시로 넣어 볼 프로필 이미지
+import profileimg from "../../assets/profileimg1.png" //예시로 넣어 볼 프로필 이미지
 
 const Header = () => {
   // 로그인 상태와 사용자 정보를 관리할 상태 변수
@@ -22,7 +22,7 @@ const Header = () => {
     // 3: 로그인 후 (프로필 설정 완료)
     // setIsLoggedIn(true);
     // setIsFirstLogin(false);
-    // setProfileImg(profileimg1);
+    // setProfileImg(profileimg);
   }, []); // 빈 배열을 넣어 useEffect가 컴포넌트 마운트 시 한 번만 실행되도록 함
 
   return (
@@ -35,7 +35,7 @@ const Header = () => {
       {isLoggedIn ? (
         isFirstLogin ? null : (
           <div className="profile-menu">
-            <img src={profileImg} className='profile-img' alt="Profile" />
+            <img src={profileImg} className='header-profile' alt="Profile" />
             <div className="dropdown-content">
               <Link to="/mypage">마이페이지</Link>
               <Link to="/planner">플래너</Link>


### PR DESCRIPTION
## 관련 IssueNumber

> #140

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 로그인 여부에 따라 헤더를 세가지의 구성으로 나누어서 렌더링해야 하는 부분이 있어서 해당 부분을 구현하였습니다.
- 아직 로그인 로직이 구현되지 않아 우선 세가지의 상황을 주석처리 해가며 확인하였습니다.

## 테스트 및 결과
<img width="566" alt="image" src="https://github.com/user-attachments/assets/afd0bf04-d580-47c1-95a9-05932446d04a">
우선 변수는 다음과 같이 담았습니다.
useEffect를 통해 컴포넌트 마운트 시 내용을 판단하여 내부 구조를 변경하도록 하였습니다.


### 1. 로그인 전 - 랜딩페이지에서 보일 로그인 전 메인 화면의 헤더 입니다.
<img width="220" alt="image" src="https://github.com/user-attachments/assets/a7820f4d-a415-4804-a740-464e3728f7ee">
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/97c784ce-4d7d-486d-9807-ab0dbd111251">
- '로그인' 버튼을 누르면 /login 페이지로 연동됩니다.


### 2. 최초 로그인 후 프로필 정보 입력 페이지의 헤더 
<img width="307" alt="image" src="https://github.com/user-attachments/assets/e1592d17-1690-4060-bfcc-231daee19ecb">
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/77ba0548-e6ae-44b9-b911-1bc1491e5770">
- /signup/profile , /signup/livinginfo, /signup/interestedplace 에서는 아무것도 보이지 않도록 하였습니다.

### 3. 로그인 후 - 프로필이미지가 보이고 드롭다운으로 메뉴를 보여줍니다.
<img width="253" alt="image" src="https://github.com/user-attachments/assets/65229e29-1896-492f-b324-d4f735cc381d">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b0ca3701-7cf6-4972-88d7-2e93221e7aef">
드롭다운 메뉴로 마이페이지, 플래너, 로그아웃이 보여지며 마우스 hover 시 배경이 어두워지도록 하였습니다.


