### PR TITLE
[feat] 로그인 후 메인 페이지 UI 구현

### DIFF
--- a/frontend/src/components/TravelCard/TravelCard.css
+++ b/frontend/src/components/TravelCard/TravelCard.css
@@ -1,19 +1,25 @@
 .travel-card {
     position: relative;
-    width: 300px;
+    width: 100%;
+    height: auto;
     border-radius: 12px;
-    overflow: hidden; /* 내용이 넘치지 않도록 처리 */
+    overflow: hidden;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
     cursor: pointer;
     transition: filter 0.3s ease, transform 0.3s ease;
     display: flex;
     flex-direction: column;
-    justify-content: space-between; /* 콘텐츠를 세로로 분포 */
+    justify-content: space-between;
+}
+
+/* 캐러셀 내의 TravelCard에서만 그림자 제거 */
+.carousel-container .travel-card {
+    box-shadow: none;
 }
 
 .travel-card.selected {
-    filter: brightness(70%); /* 선택된 카드가 어두워지도록 설정 */
-    transform: scale(0.98); /* 선택된 카드가 약간 작아지는 효과 */
+    filter: brightness(70%);
+    transform: scale(0.98);
 }
 
 .travel-card-image {
@@ -21,7 +27,7 @@
     height: 70%;
     object-fit: cover;
     display: block;
-    margin: 0; /* 이미지 하단에 여백이 생기지 않도록 설정 */
+    margin: 0;
 }
 
 .travel-card-content {
@@ -30,8 +36,8 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    margin-top: 0; /* 이미지와 내용 사이의 여백 제거 */
-    flex-grow: 1; /* 남는 공간을 채우도록 확장 */
+    margin-top: 0;
+    flex-grow: 1;
 }
 
 .travel-card-tags {

--- a/frontend/src/components/TravelCarousel/TravelCarousel.css
+++ b/frontend/src/components/TravelCarousel/TravelCarousel.css
@@ -35,6 +35,9 @@
     padding: 10px;
     cursor: pointer;
     z-index: 1;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
 }
 
 .carousel-button.prev {

--- a/frontend/src/components/TravelCarousel/TravelCarousel.css
+++ b/frontend/src/components/TravelCarousel/TravelCarousel.css
@@ -1,0 +1,48 @@
+.carousel-container {
+    position: relative;
+    width: 100%;
+    max-width: 1200px;
+    margin: auto;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    padding: 20px 0;
+}
+
+.carousel {
+    width: 100%;
+    overflow: hidden;
+}
+
+.carousel-track {
+    display: flex;
+    transition: transform 0.5s ease-in-out;
+    width: 100%;
+}
+
+.carousel-card {
+    flex: 0 0 calc(20% - 20px);
+    box-sizing: border-box;
+    margin: 0 10px;
+    padding: 0;
+    transition: transform 0.5s ease-in-out;
+}
+
+.carousel-button {
+    background-color: rgba(0, 0, 0, 0.5);
+    border: none;
+    color: white;
+    padding: 10px;
+    cursor: pointer;
+    z-index: 1;
+}
+
+.carousel-button.prev {
+    position: absolute;
+    left: 0;
+}
+
+.carousel-button.next {
+    position: absolute;
+    right: 0;
+}

--- a/frontend/src/components/TravelCarousel/TravelCarousel.jsx
+++ b/frontend/src/components/TravelCarousel/TravelCarousel.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import TravelCard from '../TravelCard/TravelCard';
+import './TravelCarousel.css';
+
+const TravelCarousel = ({ cards }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const cardsToShow = 5;
+
+  const handlePrevClick = () => {
+    if (currentIndex === 0) {
+      setCurrentIndex(cards.length - cardsToShow);
+    } else {
+      setCurrentIndex(currentIndex - 1);
+    }
+  };
+
+  const handleNextClick = () => {
+    if (currentIndex === cards.length - cardsToShow) {
+      setCurrentIndex(0);
+    } else {
+      setCurrentIndex(currentIndex + 1);
+    }
+  };
+
+  return (
+    <div className="carousel-container">
+      <button className="carousel-button prev" onClick={handlePrevClick}>
+        ◀
+      </button>
+      <div className="carousel">
+        <div
+          className="carousel-track"
+          style={{ transform: `translateX(-${currentIndex * (100 / cardsToShow)}%)` }}
+        >
+          {cards.map((card, index) => (
+            <div key={index} className="carousel-card">
+              <TravelCard {...card} isSelected={false} onClick={() => console.log(`Clicked on ${card.title}`)} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <button className="carousel-button next" onClick={handleNextClick}>
+        ▶
+      </button>
+    </div>
+  );
+};
+
+export default TravelCarousel;

--- a/frontend/src/pages/Home/Home.css
+++ b/frontend/src/pages/Home/Home.css
@@ -1,0 +1,6 @@
+.carousel-description {
+    font-size: 24px;
+    font-weight: bold;
+    margin: 20px;
+    margin-left: 10%;
+}

--- a/frontend/src/pages/Home/Home.css
+++ b/frontend/src/pages/Home/Home.css
@@ -4,3 +4,40 @@
     margin: 20px;
     margin-left: 10%;
 }
+
+.keyword-recommendation {
+    margin-top: 5%;
+}
+
+.keyword-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+    margin-left: 10%;
+}
+  
+.keyword-button {
+    background-color: white;
+    border-radius: 12px;
+    padding: 4px 8px;
+    font-size: 14px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.3s ease;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+  
+.keyword-button.selected {
+    background-color: #e6e0d7;
+    transform: scale(0.98);
+}
+  
+.keyword-button:hover {
+    background-color: #f0f0f0;
+}
+  
+.keyword-button:active {
+    transform: scale(0.95);
+}
+  

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TravelCarousel from '../../components/TravelCarousel/TravelCarousel';
 import travelcardimg from "../../assets/travelcard.png";
+import './Home.css'
 
 const data = [
   { id: 1, image: travelcardimg, tags: ["20대", "연인"], title: "롯데월드", location: "서울특별시 송파구" },
@@ -38,6 +39,11 @@ const data = [
 const Home = () => {
   return (
     <div>
+      <section className='ai-recommendation'>
+        <div className='carousel-description'>
+          <span style={{ color: '#C493FF' }}>모행 AI</span>를 이용한 맞춤 여행지
+        </div>
+      </section>
       <TravelCarousel cards={data} />
     </div>
     

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -1,5 +1,48 @@
+import React from 'react';
+import TravelCarousel from '../../components/TravelCarousel/TravelCarousel';
+import travelcardimg from "../../assets/travelcard.png";
+
+const data = [
+  { id: 1, image: travelcardimg, tags: ["20대", "연인"], title: "롯데월드", location: "서울특별시 송파구" },
+  { id: 2, image: travelcardimg, tags: ["가족", "아이"], title: "에버랜드", location: "경기도 용인시" },
+  { id: 3, image: travelcardimg, tags: ["자연", "힐링"], title: "남이섬", location: "강원도 춘천시" },
+  { id: 4, image: travelcardimg, tags: ["역사", "문화"], title: "경복궁", location: "서울특별시 종로구" },
+  { id: 5, image: travelcardimg, tags: ["해변", "휴양"], title: "해운대", location: "부산광역시" },
+  { id: 6, image: travelcardimg, tags: ["쇼핑", "문화"], title: "명동", location: "서울특별시 중구" },
+  { id: 7, image: travelcardimg, tags: ["공원", "자연"], title: "올림픽공원", location: "서울특별시 송파구" },
+  { id: 8, image: travelcardimg, tags: ["문화", "예술"], title: "인사동", location: "서울특별시 종로구" },
+  { id: 9, image: travelcardimg, tags: ["휴양", "해변"], title: "제주도", location: "제주특별자치도" },
+  { id: 10, image: travelcardimg, tags: ["자연", "등산"], title: "북한산", location: "서울특별시 은평구" },
+  { id: 11, image: travelcardimg, tags: ["연인", "데이트"], title: "청계천", location: "서울특별시 중구" },
+  { id: 12, image: travelcardimg, tags: ["역사", "문화"], title: "창덕궁", location: "서울특별시 종로구" },
+  { id: 13, image: travelcardimg, tags: ["자연", "관광"], title: "동해안", location: "강원도 동해시" },
+  { id: 14, image: travelcardimg, tags: ["산책", "데이트"], title: "한강공원", location: "서울특별시 마포구" },
+  { id: 15, image: travelcardimg, tags: ["전통", "역사"], title: "안동하회마을", location: "경상북도 안동시" },
+  { id: 16, image: travelcardimg, tags: ["공원", "자연"], title: "서울숲", location: "서울특별시 성동구" },
+  { id: 17, image: travelcardimg, tags: ["문화", "예술"], title: "부산영화의전당", location: "부산광역시 해운대구" },
+  { id: 18, image: travelcardimg, tags: ["해변", "휴양"], title: "광안리", location: "부산광역시 수영구" },
+  { id: 19, image: travelcardimg, tags: ["산책", "자연"], title: "양재천", location: "서울특별시 서초구" },
+  { id: 20, image: travelcardimg, tags: ["휴양", "온천"], title: "온천지구", location: "부산광역시 동래구" },
+  { id: 21, image: travelcardimg, tags: ["공원", "역사"], title: "서울올림픽공원", location: "서울특별시 송파구" },
+  { id: 22, image: travelcardimg, tags: ["산책", "데이트"], title: "석촌호수", location: "서울특별시 송파구" },
+  { id: 23, image: travelcardimg, tags: ["바다", "관광"], title: "통영", location: "경상남도 통영시" },
+  { id: 24, image: travelcardimg, tags: ["쇼핑", "문화"], title: "가로수길", location: "서울특별시 강남구" },
+  { id: 25, image: travelcardimg, tags: ["자연", "힐링"], title: "속초", location: "강원도 속초시" },
+  { id: 26, image: travelcardimg, tags: ["전통", "문화"], title: "전주한옥마을", location: "전라북도 전주시" },
+  { id: 27, image: travelcardimg, tags: ["해변", "휴양"], title: "망상해변", location: "강원도 동해시" },
+  { id: 28, image: travelcardimg, tags: ["산책", "공원"], title: "북서울꿈의숲", location: "서울특별시 강북구" },
+  { id: 29, image: travelcardimg, tags: ["힐링", "온천"], title: "설악산온천", location: "강원도 속초시" },
+  { id: 30, image: travelcardimg, tags: ["자연", "관광"], title: "설악산", location: "강원도 속초시" }
+];
+
 const Home = () => {
-    return <div>Home</div>;
-  };
-  
-  export default Home;
+  return (
+    <div>
+      <TravelCarousel cards={data} />
+    </div>
+    
+  );
+};
+
+export default Home;
+

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useState} from 'react';
 import TravelCarousel from '../../components/TravelCarousel/TravelCarousel';
 import travelcardimg from "../../assets/travelcard.png";
 import './Home.css'
@@ -37,18 +37,67 @@ const data = [
 ];
 
 const Home = () => {
+  const [filteredCards, setFilteredCards] = useState(data);
+  const [selectedKeywords, setSelectedKeywords] = useState([]);
+
+  // 중복 제거한 모든 키워드
+  const uniqueKeywords = Array.from(new Set(data.flatMap(card => card.tags)));
+
+  // 키워드 클릭 핸들러
+  const handleKeywordClick = (keyword) => {
+    let updatedKeywords;
+    if (selectedKeywords.includes(keyword)) {
+      // 이미 선택된 키워드를 다시 클릭하면 선택 해제
+      updatedKeywords = selectedKeywords.filter(k => k !== keyword);
+    } else {
+      // 선택된 키워드를 추가
+      updatedKeywords = [...selectedKeywords, keyword];
+    }
+
+    setSelectedKeywords(updatedKeywords);
+
+    if (updatedKeywords.length === 0) {
+      setFilteredCards(data); // 모든 키워드 선택 해제 시 전체 카드 보여줌
+    } else {
+      // 선택된 키워드 중 하나라도 포함된 카드들을 필터링
+      setFilteredCards(
+        data.filter(card => 
+          updatedKeywords.every(keyword => card.tags.includes(keyword))
+        )
+      );
+    }
+  };
+
   return (
     <div>
       <section className='ai-recommendation'>
         <div className='carousel-description'>
-          <span style={{ color: '#C493FF' }}>모행 AI</span>를 이용한 맞춤 여행지
+          <span style={{ color: '#845EC2' }}>모행 AI</span>를 이용한 맞춤 여행지
         </div>
+        <TravelCarousel cards={data} />
       </section>
-      <TravelCarousel cards={data} />
+
+      <section className='keyword-recommendation'>
+        <div className='carousel-description'>
+          <span style={{ color: '#845EC2' }}>#키워드</span> 추천 여행지
+        </div>
+
+        <div className='keyword-buttons'>
+          {uniqueKeywords.map((keyword, index) => (
+            <button
+              key={index}
+              className={`keyword-button ${selectedKeywords.includes(keyword) ? 'selected' : ''}`}
+              onClick={() => handleKeywordClick(keyword)}
+            >
+              #{keyword}
+            </button>
+          ))}
+        </div>
+
+        <TravelCarousel cards={filteredCards} />
+      </section>
     </div>
-    
   );
 };
 
 export default Home;
-


### PR DESCRIPTION
## 관련 IssueNumber

> #145

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 로그인 후 볼 수 있는 메인페이지를 구현하였습니다.
- 한 번에 5장의 여행지 카드를 볼 수 있으며 캐러셀 구조로 되어 있어 화살표를 누르면 옆으로 한칸씩 이동합니다.
- 위쪽은 AI를 통한 추천 여행지, 아래쪽은 키워드를 통한 필터링기능이 추가되어 있습니다.
- 키워드는 중복 선택이 가능하며 현재는 우선 더미 데이터에서 키워드를 추출해 테스트해보았습니다. 


## 관련 스크린샷 및 참고자료
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ccc4ce3e-d915-4619-ac0b-6a844ba066cf">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6f164f5b-f1ba-4e93-8434-3d47d95dc2cc">
자연 키워드를 선택하여 필터링된 결과를 보여줌