### PR TITLE
[feat] 비슷한 여행지 조회시 생활정보로 필터링하여 10개의 여행지를 찾도록 구현 

### DIFF
--- a/backend/src/main/java/moheng/auth/application/AuthService.java
+++ b/backend/src/main/java/moheng/auth/application/AuthService.java
@@ -61,8 +61,8 @@ public class AuthService {
 
     @Transactional
     public RenewalAccessTokenResponse generateRenewalAccessToken(final RenewalAccessTokenRequest renewalAccessTokenRequest) {
-        String refreshToken = renewalAccessTokenRequest.getRefreshToken();
-        RenewalToken renewalToken = tokenManager.generateRenewalAccessToken(refreshToken);
+        final String refreshToken = renewalAccessTokenRequest.getRefreshToken();
+        final RenewalToken renewalToken = tokenManager.generateRenewalAccessToken(refreshToken);
         return new RenewalAccessTokenResponse(renewalToken.getAccessToken());
     }
 

--- a/backend/src/main/java/moheng/auth/domain/oauth/OAuthClient.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/OAuthClient.java
@@ -3,5 +3,5 @@ package moheng.auth.domain.oauth;
 
 public interface OAuthClient {
     OAuthMember getOAuthMember(final String code);
-    boolean isSame(String oAuthProviderName);
+    boolean isSame(final String oAuthProviderName);
 }

--- a/backend/src/main/java/moheng/auth/domain/oauth/OAuthClientProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/OAuthClientProvider.java
@@ -13,7 +13,7 @@ public class OAuthClientProvider implements OAuthProvider {
     private final List<OAuthClient> oAuthClients;
     private final List<OAuthUriProvider> oAuthUriProviders;
 
-    public OAuthClientProvider(List<OAuthClient> oAuthClients, List<OAuthUriProvider> oAuthUriProviders) {
+    public OAuthClientProvider(final List<OAuthClient> oAuthClients, final List<OAuthUriProvider> oAuthUriProviders) {
         this.oAuthClients = oAuthClients;
         this.oAuthUriProviders = oAuthUriProviders;
     }

--- a/backend/src/main/java/moheng/auth/domain/oauth/OAuthProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/OAuthProvider.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 public interface OAuthProvider {
     OAuthClient getOauthClient(final String providerName);
     OAuthUriProvider getOAuthUriProvider(final String providerName);
-    SocialType getSocialType(String provider);
+    SocialType getSocialType(final String provider);
 }

--- a/backend/src/main/java/moheng/auth/domain/oauth/OAuthUriProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/oauth/OAuthUriProvider.java
@@ -3,5 +3,5 @@ package moheng.auth.domain.oauth;
 
 public interface OAuthUriProvider {
     String generateUri();
-    boolean isSame(String provider);
+    boolean isSame(final String provider);
 }

--- a/backend/src/main/java/moheng/auth/domain/token/InMemoryRefreshTokenRepository.java
+++ b/backend/src/main/java/moheng/auth/domain/token/InMemoryRefreshTokenRepository.java
@@ -38,7 +38,7 @@ public class InMemoryRefreshTokenRepository implements RefreshTokenRepository {
     }
 
     @Override
-    public long deleteByRefreshToken(String refreshToken) {
+    public long deleteByRefreshToken(final String refreshToken) {
         return repository.entrySet().stream()
                 .filter(data -> data.getValue().equals(refreshToken)).findFirst()
                 .map(data -> {

--- a/backend/src/main/java/moheng/auth/domain/token/JwtTokenManager.java
+++ b/backend/src/main/java/moheng/auth/domain/token/JwtTokenManager.java
@@ -18,8 +18,8 @@ public class JwtTokenManager implements TokenManager {
 
     @Override
     public MemberToken createMemberToken(final long memberId) {
-        String accessToken = tokenProvider.createAccessToken(memberId);
-        String refreshToken = createRefreshToken(memberId);
+        final String accessToken = tokenProvider.createAccessToken(memberId);
+        final String refreshToken = createRefreshToken(memberId);
         return new MemberToken(accessToken, refreshToken);
     }
 
@@ -27,7 +27,7 @@ public class JwtTokenManager implements TokenManager {
         if (refreshTokenRepository.existsById(memberId)) {
             return refreshTokenRepository.findById(memberId);
         }
-        String refreshToken = tokenProvider.createRefreshToken(memberId);
+        final String refreshToken = tokenProvider.createRefreshToken(memberId);
         refreshTokenRepository.save(memberId, refreshToken);
         return refreshToken;
     }
@@ -36,14 +36,14 @@ public class JwtTokenManager implements TokenManager {
     public RenewalToken generateRenewalAccessToken(final String refreshToken) {
         deleteExpiredRefreshToken(refreshToken);
 
-        Long memberId = tokenProvider.getMemberId(refreshToken);
+        final Long memberId = tokenProvider.getMemberId(refreshToken);
         if(!refreshTokenRepository.existsById(memberId)) {
             throw new NoExistMemberTokenException("존재하지 않는 유저의 토큰입니다.");
         }
 
-        String accessTokenForRenew = tokenProvider.createAccessToken(memberId);
-        String refreshTokenForRenew = refreshTokenRepository.findById(memberId);
-        RenewalToken renewalToken = new RenewalToken(accessTokenForRenew, refreshTokenForRenew);
+        final String accessTokenForRenew = tokenProvider.createAccessToken(memberId);
+        final String refreshTokenForRenew = refreshTokenRepository.findById(memberId);
+        final RenewalToken renewalToken = new RenewalToken(accessTokenForRenew, refreshTokenForRenew);
         renewalToken.validateHasSameRefreshToken(refreshToken);
 
         return renewalToken;
@@ -65,7 +65,7 @@ public class JwtTokenManager implements TokenManager {
     @Override
     public void removeRefreshToken(final String refreshToken) {
         tokenProvider.validateToken(refreshToken);
-        long memberId = getMemberId(refreshToken);
+        final long memberId = getMemberId(refreshToken);
 
         if(!refreshTokenRepository.existsById(memberId)) {
             throw new NoExistMemberTokenException("존재하지 않는 유저의 토큰입니다.");

--- a/backend/src/main/java/moheng/auth/domain/token/JwtTokenProvider.java
+++ b/backend/src/main/java/moheng/auth/domain/token/JwtTokenProvider.java
@@ -48,7 +48,7 @@ public class JwtTokenProvider implements TokenProvider {
     @Override
     public void validateToken(final String token) {
         try {
-            Jws<Claims> claims = Jwts.parserBuilder()
+            final Jws<Claims> claims = Jwts.parserBuilder()
                     .setSigningKey(secretKey)
                     .build()
                     .parseClaimsJws(token);
@@ -62,7 +62,7 @@ public class JwtTokenProvider implements TokenProvider {
     @Override
     public boolean isRefreshTokenExpired(final String token) {
         try {
-            Jws<Claims> claims = Jwts.parserBuilder()
+            final Jws<Claims> claims = Jwts.parserBuilder()
                     .setSigningKey(secretKey)
                     .build()
                     .parseClaimsJws(token);
@@ -74,8 +74,8 @@ public class JwtTokenProvider implements TokenProvider {
     }
 
     public String createToken(final String payload, final long tokenValidityInSeconds) {
-        Date now = new Date();
-        Date expireDate = new Date(now.getTime() + tokenValidityInSeconds);
+        final Date now = new Date();
+        final Date expireDate = new Date(now.getTime() + tokenValidityInSeconds);
 
         return Jwts.builder()
                 .setSubject(payload)

--- a/backend/src/main/java/moheng/auth/domain/token/MemberToken.java
+++ b/backend/src/main/java/moheng/auth/domain/token/MemberToken.java
@@ -4,7 +4,7 @@ public class MemberToken {
     private final String accessToken;
     private final String refreshToken;
 
-    public MemberToken(String accessToken, String refreshToken) {
+    public MemberToken(final String accessToken, final String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }

--- a/backend/src/main/java/moheng/auth/domain/token/RenewalToken.java
+++ b/backend/src/main/java/moheng/auth/domain/token/RenewalToken.java
@@ -3,8 +3,8 @@ package moheng.auth.domain.token;
 import moheng.auth.exception.NoExistMemberTokenException;
 
 public class RenewalToken {
-    private String accessToken;
-    private String refreshToken;
+    private final String accessToken;
+    private final String refreshToken;
 
     public RenewalToken(final String accessToken, final String refreshToken) {
         this.accessToken = accessToken;
@@ -15,7 +15,7 @@ public class RenewalToken {
         return accessToken;
     }
 
-    public void validateHasSameRefreshToken(String otherRefreshToken) {
+    public void validateHasSameRefreshToken(final String otherRefreshToken) {
         if (!refreshToken.equals(otherRefreshToken)) {
             throw new NoExistMemberTokenException("회원의 리프레시 토큰이 아닙니다.");
         }

--- a/backend/src/main/java/moheng/auth/dto/AccessTokenResponse.java
+++ b/backend/src/main/java/moheng/auth/dto/AccessTokenResponse.java
@@ -7,7 +7,7 @@ public class AccessTokenResponse {
     private AccessTokenResponse() {
     }
 
-    public AccessTokenResponse(String accessToken) {
+    public AccessTokenResponse(final String accessToken) {
         this.accessToken = accessToken;
     }
 

--- a/backend/src/main/java/moheng/auth/dto/Accessor.java
+++ b/backend/src/main/java/moheng/auth/dto/Accessor.java
@@ -6,7 +6,7 @@ public class Accessor {
     private Accessor() {
     }
 
-    public Accessor(Long id) {
+    public Accessor(final Long id) {
         this.id = id;
     }
 

--- a/backend/src/main/java/moheng/auth/dto/RenewalAccessTokenResponse.java
+++ b/backend/src/main/java/moheng/auth/dto/RenewalAccessTokenResponse.java
@@ -9,7 +9,7 @@ public class RenewalAccessTokenResponse {
     private RenewalAccessTokenResponse() {
     }
 
-    public RenewalAccessTokenResponse(String accessToken) {
+    public RenewalAccessTokenResponse(final String accessToken) {
         this.accessToken = accessToken;
     }
 

--- a/backend/src/main/java/moheng/auth/exception/BadRequestException.java
+++ b/backend/src/main/java/moheng/auth/exception/BadRequestException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class BadRequestException extends RuntimeException {
-    public BadRequestException(String message) {
+    public BadRequestException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/EmptyBearerHeaderException.java
+++ b/backend/src/main/java/moheng/auth/exception/EmptyBearerHeaderException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class EmptyBearerHeaderException extends RuntimeException {
-    public EmptyBearerHeaderException(String message) {
+    public EmptyBearerHeaderException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/InvalidInitAuthorityException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidInitAuthorityException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class InvalidInitAuthorityException extends RuntimeException {
-    public InvalidInitAuthorityException(String message) {
+    public InvalidInitAuthorityException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/InvalidOAuthServiceException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidOAuthServiceException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class InvalidOAuthServiceException extends RuntimeException {
-    public InvalidOAuthServiceException(String message) {
+    public InvalidOAuthServiceException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/InvalidRegularAuthorityException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidRegularAuthorityException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class InvalidRegularAuthorityException extends RuntimeException {
-    public InvalidRegularAuthorityException(String message) {
+    public InvalidRegularAuthorityException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/InvalidTokenException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidTokenException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class InvalidTokenException extends RuntimeException {
-    public InvalidTokenException(String message) {
+    public InvalidTokenException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/InvalidTokenFormatException.java
+++ b/backend/src/main/java/moheng/auth/exception/InvalidTokenFormatException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class InvalidTokenFormatException extends RuntimeException {
-    public InvalidTokenFormatException(String message) {
+    public InvalidTokenFormatException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/NoExistMemberTokenException.java
+++ b/backend/src/main/java/moheng/auth/exception/NoExistMemberTokenException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class NoExistMemberTokenException extends RuntimeException {
-    public NoExistMemberTokenException(String message) {
+    public NoExistMemberTokenException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/auth/exception/NoExistOAuthClientException.java
+++ b/backend/src/main/java/moheng/auth/exception/NoExistOAuthClientException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class NoExistOAuthClientException extends RuntimeException {
-    public NoExistOAuthClientException(String message) {
+    public NoExistOAuthClientException(final String message) {
         super(message);
     }
 

--- a/backend/src/main/java/moheng/auth/exception/NoMatchingSocialTypeException.java
+++ b/backend/src/main/java/moheng/auth/exception/NoMatchingSocialTypeException.java
@@ -1,7 +1,7 @@
 package moheng.auth.exception;
 
 public class NoMatchingSocialTypeException extends RuntimeException {
-    public NoMatchingSocialTypeException(String message) {
+    public NoMatchingSocialTypeException(final String message) {
         super(message);
     }
 

--- a/backend/src/main/java/moheng/auth/infrastructure/KakaoOAuthClient.java
+++ b/backend/src/main/java/moheng/auth/infrastructure/KakaoOAuthClient.java
@@ -45,7 +45,7 @@ public class KakaoOAuthClient implements OAuthClient {
     }
 
     @Override
-    public boolean isSame(String providerName) {
+    public boolean isSame(final String providerName) {
         return PROVIDER_NAME.equals(providerName);
     }
 
@@ -73,7 +73,7 @@ public class KakaoOAuthClient implements OAuthClient {
         throw new InvalidOAuthServiceException("카카오 OAuth 소셜 로그인 서버에 예기치 못한 오류가 발생했습니다.");
     }
 
-    private String requestKakaoAccessToken(String code) {
+    private String requestKakaoAccessToken(final String code) {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setBasicAuth(clientId, clientSecret);

--- a/backend/src/main/java/moheng/auth/infrastructure/KakaoOAuthMember.java
+++ b/backend/src/main/java/moheng/auth/infrastructure/KakaoOAuthMember.java
@@ -17,20 +17,18 @@ public class KakaoOAuthMember implements OAuthMember {
         private String email;
     }
 
-    public KakaoOAuthMember(String email, String socialLoginId) {
+    public KakaoOAuthMember(final String email, final String socialLoginId) {
         this.socialLoginId = socialLoginId;
         this.kakaoAccount = new KakaoAccount();
         this.kakaoAccount.email = email;
     }
 
     @Override
-    @Generated
     public String getSocialLoginId() {
         return socialLoginId;
     }
 
     @Override
-    @Generated
     public String getEmail() {
         return kakaoAccount.email;
     }

--- a/backend/src/main/java/moheng/auth/infrastructure/OAuthAccessToken.java
+++ b/backend/src/main/java/moheng/auth/infrastructure/OAuthAccessToken.java
@@ -20,7 +20,6 @@ public class OAuthAccessToken {
     @JsonProperty("refresh_token")
     private String refreshToken;
 
-    @Generated
     public String getAccessToken() {
         return accessToken;
     }

--- a/backend/src/main/java/moheng/auth/presentation/AuthController.java
+++ b/backend/src/main/java/moheng/auth/presentation/AuthController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
 

--- a/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationBearerExtractor.java
+++ b/backend/src/main/java/moheng/auth/presentation/authentication/AuthenticationBearerExtractor.java
@@ -16,7 +16,7 @@ public class AuthenticationBearerExtractor {
     }
 
     public String extract(final HttpServletRequest httpServletRequest) {
-        String authorizationHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        final String authorizationHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
 
         validateEmptyHeader(authorizationHeader);
         validateAuthorizationFormat(authorizationHeader);

--- a/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
+++ b/backend/src/main/java/moheng/auth/presentation/initauthentication/InitAuthenticationArgumentResolver.java
@@ -53,7 +53,7 @@ public class InitAuthenticationArgumentResolver implements HandlerMethodArgument
         jwtTokenProvider.validateToken(accessToken);
         final Long id = jwtTokenProvider.getMemberId(accessToken);
 
-        Member member = memberRepository.findById(id)
+        final Member member = memberRepository.findById(id)
                 .orElseThrow(NoExistMemberException::new);
 
         if(!member.getAuthority().equals(Authority.INIT_MEMBER)) {

--- a/backend/src/main/java/moheng/keyword/application/KeywordFilterModelClient.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordFilterModelClient.java
@@ -5,5 +5,5 @@ import moheng.keyword.dto.TripRecommendByKeywordRequest;
 
 
 public interface KeywordFilterModelClient {
-    TripContentIdsByKeywordResponse findRecommendTripContentIdsByKeywords(TripRecommendByKeywordRequest request);
+    TripContentIdsByKeywordResponse findRecommendTripContentIdsByKeywords(final TripRecommendByKeywordRequest request);
 }

--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -68,19 +68,19 @@ public class KeywordService {
                 .orElseThrow(() -> new NoExistKeywordException("랜덤 키워드를 찾을 수 없습니다."));
     }
 
-    private void validateKeywordRange(Long minId, Long maxId) {
+    private void validateKeywordRange(final Long minId, final Long maxId) {
         if (minId == null || maxId == null) {
             throw new NoExistKeywordException("랜덤 키워드를 찾을 수 없습니다.");
         }
     }
 
-    private Long generateRandomId(Long minId, Long maxId) {
-        SecureRandom secureRandom = new SecureRandom();
+    private Long generateRandomId(final Long minId, final Long maxId) {
+        final SecureRandom secureRandom = new SecureRandom();
         return minId + secureRandom.nextLong(maxId - minId + 1);
     }
 
 
-    private Map<Trip, Long> findTripsWithVisitedCount(List<TripKeyword> tripKeywords) {
+    private Map<Trip, Long> findTripsWithVisitedCount(final List<TripKeyword> tripKeywords) {
         final Map<Trip, Long> tripClickCounts = new HashMap<>();
         for (TripKeyword tripKeyword : tripKeywords) {
             Trip trip = tripKeyword.getTrip();
@@ -89,7 +89,7 @@ public class KeywordService {
         return tripClickCounts;
     }
 
-    private List<Trip> findTopTripsByVisitedCount(Map<Trip, Long> tripsWithVisitedCount) {
+    private List<Trip> findTopTripsByVisitedCount(final Map<Trip, Long> tripsWithVisitedCount) {
         return tripsWithVisitedCount.entrySet().stream()
                 .sorted((entry1, entry2) -> entry2.getValue().compareTo(entry1.getValue()))
                 .limit(30)

--- a/backend/src/main/java/moheng/keyword/domain/KeywordRepository.java
+++ b/backend/src/main/java/moheng/keyword/domain/KeywordRepository.java
@@ -10,10 +10,10 @@ import java.util.Optional;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     @Query("SELECT k.name FROM Keyword k WHERE k.id IN :keywordIds")
-    List<String> findNamesByIds(@Param("keywordIds") List<Long> keywordIds);
+    List<String> findNamesByIds(@Param("keywordIds") final List<Long> keywordIds);
 
     @Query("SELECT k FROM Keyword k WHERE k.id = :id")
-    Optional<Keyword> findKeywordById(@Param("id") Long id);
+    Optional<Keyword> findKeywordById(@Param("id") final Long id);
 
     @Query("SELECT MIN(k.id) FROM Keyword k")
     Long findMinKeywordId();

--- a/backend/src/main/java/moheng/keyword/exception/InvalidAIServerException.java
+++ b/backend/src/main/java/moheng/keyword/exception/InvalidAIServerException.java
@@ -1,7 +1,7 @@
 package moheng.keyword.exception;
 
 public class InvalidAIServerException extends RuntimeException {
-    public InvalidAIServerException(String message) {
+    public InvalidAIServerException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/keyword/exception/KeywordNameLengthException.java
+++ b/backend/src/main/java/moheng/keyword/exception/KeywordNameLengthException.java
@@ -1,7 +1,7 @@
 package moheng.keyword.exception;
 
 public class KeywordNameLengthException extends RuntimeException {
-    public KeywordNameLengthException(String message) {
+    public KeywordNameLengthException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/keyword/exception/NoExistKeywordException.java
+++ b/backend/src/main/java/moheng/keyword/exception/NoExistKeywordException.java
@@ -1,7 +1,7 @@
 package moheng.keyword.exception;
 
 public class NoExistKeywordException extends RuntimeException {
-    public NoExistKeywordException(String message) {
+    public NoExistKeywordException(final String message) {
         super(message);
     }
 

--- a/backend/src/main/java/moheng/keyword/exception/NoExistTripKeywordException.java
+++ b/backend/src/main/java/moheng/keyword/exception/NoExistTripKeywordException.java
@@ -1,7 +1,7 @@
 package moheng.keyword.exception;
 
 public class NoExistTripKeywordException extends RuntimeException {
-    public NoExistTripKeywordException(String message) {
+    public NoExistTripKeywordException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/keyword/infrastructure/AiKeywordModelClient.java
+++ b/backend/src/main/java/moheng/keyword/infrastructure/AiKeywordModelClient.java
@@ -22,7 +22,7 @@ public class AiKeywordModelClient implements KeywordFilterModelClient {
         return requestRecommendTrips(request);
     }
 
-    private TripContentIdsByKeywordResponse requestRecommendTrips(TripRecommendByKeywordRequest request) {
+    private TripContentIdsByKeywordResponse requestRecommendTrips(final TripRecommendByKeywordRequest request) {
         final ResponseEntity<TripContentIdsByKeywordResponse> contentIds = restTemplate.postForEntity(RECOMMEND_TRIP_LIST_BY_KEYWORD_REQUEST_URL, request, TripContentIdsByKeywordResponse.class);
 
         if(contentIds.getStatusCode().is2xxSuccessful()) {

--- a/backend/src/main/java/moheng/keyword/presentation/KeywordController.java
+++ b/backend/src/main/java/moheng/keyword/presentation/KeywordController.java
@@ -11,7 +11,7 @@ import moheng.trip.dto.TripKeywordCreateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/keyword")
+@RequestMapping("/api/keyword")
 @RestController
 public class KeywordController {
     private final KeywordService keywordService;

--- a/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/LiveInformationService.java
@@ -23,7 +23,8 @@ public class LiveInformationService {
     private final TripRepository tripRepository;
 
     public LiveInformationService(final LiveInformationRepository liveInformationRepository,
-                                  final TripLiveInformationRepository tripLiveInformationRepository, TripRepository tripRepository) {
+                                  final TripLiveInformationRepository tripLiveInformationRepository,
+                                  final TripRepository tripRepository) {
         this.liveInformationRepository = liveInformationRepository;
         this.tripLiveInformationRepository = tripLiveInformationRepository;
         this.tripRepository = tripRepository;
@@ -34,7 +35,7 @@ public class LiveInformationService {
     }
 
     @Transactional
-    public void createLiveInformation(LiveInformationCreateRequest request) {
+    public void createLiveInformation(final LiveInformationCreateRequest request) {
         final LiveInformation liveInformation = new LiveInformation(request.getName());
         liveInformationRepository.save(liveInformation);
     }
@@ -49,11 +50,11 @@ public class LiveInformationService {
     }
 
     @Transactional
-    public LiveInformation save(LiveInformation liveInformation) {
+    public LiveInformation save(final LiveInformation liveInformation) {
         return liveInformationRepository.save(liveInformation);
     }
 
-    public LiveInformation findByName(String liveTypeName) {
+    public LiveInformation findByName(final String liveTypeName) {
         return liveInformationRepository.findByName(liveTypeName)
                 .orElseThrow(() -> new NoExistLiveInformationException("존재하지 않는 생활정보입니다."));
     }

--- a/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
+++ b/backend/src/main/java/moheng/liveinformation/application/MemberLiveInformationService.java
@@ -33,22 +33,21 @@ public class MemberLiveInformationService {
         this.memberRepository = memberRepository;
     }
 
-    public void saveAll(List<MemberLiveInformation> memberLiveInformations) {
+    public void saveAll(final List<MemberLiveInformation> memberLiveInformations) {
         memberLiveInformationRepository.saveAll(memberLiveInformations);
     }
 
     @Transactional
-    public void updateMemberLiveInformation(long memberId, UpdateMemberLiveInformationRequest request) {
+    public void updateMemberLiveInformation(final long memberId, final UpdateMemberLiveInformationRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoExistMemberException("존재하지 않는 회원입니다."));
-
-        List<LiveInformation> liveInformations = liveInformationRepository.findAllById(request.getLiveInfoIds());
+        final List<LiveInformation> liveInformations = liveInformationRepository.findAllById(request.getLiveInfoIds());
         memberLiveInformationRepository.deleteByMemberId(memberId);
         saveMemberLiveInformation(liveInformations, member);
     }
 
-    private void saveMemberLiveInformation(List<LiveInformation> liveInformations, Member member) {
-        List<MemberLiveInformation> updateMemberLiveInfoList = new ArrayList<>();
+    private void saveMemberLiveInformation(final List<LiveInformation> liveInformations, final Member member) {
+        final List<MemberLiveInformation> updateMemberLiveInfoList = new ArrayList<>();
 
         for (LiveInformation liveInformation : liveInformations) {
             final MemberLiveInformation memberLiveInformation = new MemberLiveInformation(liveInformation, member);
@@ -57,7 +56,7 @@ public class MemberLiveInformationService {
         memberLiveInformationRepository.saveAll(updateMemberLiveInfoList);
     }
 
-    public FindMemberLiveInformationResponses findMemberSelectedLiveInformation(Long memberId) {
+    public FindMemberLiveInformationResponses findMemberSelectedLiveInformation(final Long memberId) {
         final List<LiveInformation> allLiveInformation = liveInformationRepository.findAll();
         final List<Long> memberLiveInfoIds = findMemberLiveInfoIds(memberId);
         return new FindMemberLiveInformationResponses(findMemberSelectedLiveInfos(allLiveInformation, memberLiveInfoIds));
@@ -69,7 +68,7 @@ public class MemberLiveInformationService {
                 .collect(Collectors.toList());
     }
 
-    private List<LiveInfoResponse> findMemberSelectedLiveInfos(final List<LiveInformation> allLiveInformation, List<Long> selectedLiveInfoIds) {
+    private List<LiveInfoResponse> findMemberSelectedLiveInfos(final List<LiveInformation> allLiveInformation, final List<Long> selectedLiveInfoIds) {
         return allLiveInformation.stream()
                 .map(liveInfo -> new LiveInfoResponse(
                         liveInfo.getId(),

--- a/backend/src/main/java/moheng/liveinformation/domain/LiveInformation.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/LiveInformation.java
@@ -21,18 +21,18 @@ public class LiveInformation extends BaseEntity {
     protected LiveInformation() {
     }
 
-    public LiveInformation(Long id, String name) {
+    public LiveInformation(final Long id, final String name) {
         validateName(name);
         this.id = id;
         this.name = name;
     }
 
-    public LiveInformation(String name) {
+    public LiveInformation(final String name) {
         validateName(name);
         this.name = name;
     }
 
-    private void validateName(String name) {
+    private void validateName(final String name) {
         if(name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
             throw new LiveInfoNameException("생활정보 이름의 길이는 최소 1자 이상, 최대 100자 이하만 허용됩니다.");
         }

--- a/backend/src/main/java/moheng/liveinformation/domain/LiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/LiveInformationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface LiveInformationRepository extends JpaRepository<LiveInformation, Long> {
-    Optional<LiveInformation> findByName(String liveId);
+    Optional<LiveInformation> findByName(final String liveId);
 
     @Query("SELECT tli.liveInformation FROM TripLiveInformation tli WHERE tli.trip = :trip")
     LiveInformation findLiveInformationByTrip(@Param("trip") final Trip trip);

--- a/backend/src/main/java/moheng/liveinformation/domain/LiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/LiveInformationRepository.java
@@ -1,9 +1,15 @@
 package moheng.liveinformation.domain;
 
+import moheng.trip.domain.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface LiveInformationRepository extends JpaRepository<LiveInformation, Long> {
     Optional<LiveInformation> findByName(String liveId);
+
+    @Query("SELECT tli.liveInformation FROM TripLiveInformation tli WHERE tli.trip = :trip")
+    LiveInformation findLiveInformationByTrip(@Param("trip") final Trip trip);
 }

--- a/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/MemberLiveInformationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface MemberLiveInformationRepository extends JpaRepository<MemberLiveInformation, Long> {
-    List<MemberLiveInformation> findByMemberId(Long memberId);
+    List<MemberLiveInformation> findByMemberId(final Long memberId);
     @Transactional
     void deleteByMemberId(Long memberId);
 

--- a/backend/src/main/java/moheng/liveinformation/domain/TripLiveInformationRepository.java
+++ b/backend/src/main/java/moheng/liveinformation/domain/TripLiveInformationRepository.java
@@ -2,6 +2,8 @@ package moheng.liveinformation.domain;
 
 import moheng.trip.domain.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 

--- a/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/LiveInfoResponse.java
@@ -8,7 +8,7 @@ public class LiveInfoResponse {
     private LiveInfoResponse() {
     }
 
-    public LiveInfoResponse(Long liveInfoId, String name, boolean contain) {
+    public LiveInfoResponse(final Long liveInfoId, final String name, boolean contain) {
         this.liveInfoId = liveInfoId;
         this.name = name;
         this.contain = contain;

--- a/backend/src/main/java/moheng/liveinformation/dto/LiveInformationCreateRequest.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/LiveInformationCreateRequest.java
@@ -6,7 +6,7 @@ public class LiveInformationCreateRequest {
     private LiveInformationCreateRequest() {
     }
 
-    public LiveInformationCreateRequest(String name) {
+    public LiveInformationCreateRequest(final String name) {
         this.name = name;
     }
 

--- a/backend/src/main/java/moheng/liveinformation/dto/MemberLiveInfo.java
+++ b/backend/src/main/java/moheng/liveinformation/dto/MemberLiveInfo.java
@@ -1,4 +1,0 @@
-package moheng.liveinformation.dto;
-
-public class MemberLiveInfo {
-}

--- a/backend/src/main/java/moheng/liveinformation/exception/EmptyLiveInformationException.java
+++ b/backend/src/main/java/moheng/liveinformation/exception/EmptyLiveInformationException.java
@@ -1,7 +1,7 @@
 package moheng.liveinformation.exception;
 
 public class EmptyLiveInformationException extends RuntimeException {
-    public EmptyLiveInformationException(String message) {
+    public EmptyLiveInformationException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/exception/LiveInfoNameException.java
+++ b/backend/src/main/java/moheng/liveinformation/exception/LiveInfoNameException.java
@@ -1,7 +1,7 @@
 package moheng.liveinformation.exception;
 
 public class LiveInfoNameException extends RuntimeException {
-    public LiveInfoNameException(String message) {
+    public LiveInfoNameException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/exception/NoExistLiveInformationException.java
+++ b/backend/src/main/java/moheng/liveinformation/exception/NoExistLiveInformationException.java
@@ -1,7 +1,7 @@
 package moheng.liveinformation.exception;
 
 public class NoExistLiveInformationException extends RuntimeException {
-    public NoExistLiveInformationException(String message) {
+    public NoExistLiveInformationException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
@@ -18,12 +18,9 @@ import java.util.List;
 @RestController
 public class LiveInformationController {
     private final LiveInformationService liveInformationService;
-    private final MemberLiveInformationService memberLiveInformationService;
 
-    public LiveInformationController(final LiveInformationService liveInformationService,
-                                     final MemberLiveInformationService memberLiveInformationService) {
+    public LiveInformationController(final LiveInformationService liveInformationService) {
         this.liveInformationService = liveInformationService;
-        this.memberLiveInformationService = memberLiveInformationService;
     }
 
     @GetMapping("/all")
@@ -32,7 +29,7 @@ public class LiveInformationController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createLiveInformation(final @RequestBody LiveInformationCreateRequest request) {
+    public ResponseEntity<Void> createLiveInformation(@RequestBody final LiveInformationCreateRequest request) {
         liveInformationService.createLiveInformation(request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/LiveInformationController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RequestMapping("/live/info")
+@RequestMapping("/api/live/info")
 @RestController
 public class LiveInformationController {
     private final LiveInformationService liveInformationService;

--- a/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
@@ -8,7 +8,7 @@ import moheng.liveinformation.dto.UpdateMemberLiveInformationRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/live/info/member")
+@RequestMapping("/api/live/info/member")
 @RestController
 public class MemberLiveInformationController {
     private final MemberLiveInformationService memberLiveInformationService;

--- a/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
+++ b/backend/src/main/java/moheng/liveinformation/presentation/MemberLiveInformationController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberLiveInformationController {
     private final MemberLiveInformationService memberLiveInformationService;
 
-    public MemberLiveInformationController(MemberLiveInformationService memberLiveInformationService) {
+    public MemberLiveInformationController(final MemberLiveInformationService memberLiveInformationService) {
         this.memberLiveInformationService = memberLiveInformationService;
     }
 

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -65,7 +65,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void save(Member member) {
+    public void save(final Member member) {
         memberRepository.save(member);
     }
 
@@ -97,7 +97,7 @@ public class MemberService {
         saveMemberLiveInformation(request.getLiveInfoNames(), member);
     }
 
-    private void saveMemberLiveInformation(List<String> liveTypeNames, Member member) {
+    private void saveMemberLiveInformation(final List<String> liveTypeNames, final Member member) {
         validateLiveTypeNames(liveTypeNames);
         final List<MemberLiveInformation> memberLiveInformationList = new ArrayList<>();
 
@@ -108,36 +108,35 @@ public class MemberService {
         memberLiveInformationService.saveAll(memberLiveInformationList);
     }
 
-    private void validateLiveTypeNames(List<String> liveTypeNames) {
+    private void validateLiveTypeNames(final List<String> liveTypeNames) {
         if(liveTypeNames == null || liveTypeNames.isEmpty()) {
             throw new EmptyLiveInformationException("생활정보를 선택하지 않았습니다.");
         }
     }
 
     @Transactional
-    public void signUpByInterestTrips(long memberId, SignUpInterestTripsRequest request) {
+    public void signUpByInterestTrips(final long memberId, final SignUpInterestTripsRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoExistMemberException("존재하지 않는 회원입니다."));
-
         saveRecommendTrip(request.getContentIds(), member, 1L);
         changeMemberPrivileges(member);
     }
 
-    private void saveRecommendTrip(List<Long> contentIds, Member member, long rank) {
+    private void saveRecommendTrip(final List<Long> contentIds, final Member member, long rank) {
         validateContentIds(contentIds);
         for (final Long contentId : contentIds) {
-            Trip trip = tripService.findByContentId(contentId);
+            final Trip trip = tripService.findByContentId(contentId);
             recommendTripService.saveByRank(trip, member, rank++);
         }
     }
 
-    private void validateContentIds(List<Long> contentIds) {
+    private void validateContentIds(final List<Long> contentIds) {
         if(contentIds.size() < MIN_RECOMMEND_TRIP_SIZE || contentIds.size() > MAX_RECOMMEND_TRIP_SIZE)  {
             throw new ShortContentidsSizeException("AI 맞춤 추천을 위해 관심 여행지를 5개 이상, 10개 이하로 선택해야합니다.");
         }
     }
 
-    private void changeMemberPrivileges(Member member) {
+    private void changeMemberPrivileges(final Member member) {
         member.changePrivilege(Authority.REGULAR_MEMBER);
     }
 
@@ -159,7 +158,7 @@ public class MemberService {
         memberRepository.save(updateMember);
     }
 
-    public void checkIsAlreadyExistNickname(String nickname) {
+    public void checkIsAlreadyExistNickname(final String nickname) {
         if(isAlreadyExistNickname(nickname)) {
             throw new DuplicateNicknameException("중복되는 닉네임이 존재합니다.");
         }

--- a/backend/src/main/java/moheng/member/domain/Member.java
+++ b/backend/src/main/java/moheng/member/domain/Member.java
@@ -83,7 +83,7 @@ public class Member extends BaseEntity {
         this.authority = Authority.REGULAR_MEMBER;
     }
 
-    public void changePrivilege(Authority authority) {
+    public void changePrivilege(final Authority authority) {
         this.authority = authority;
     }
 

--- a/backend/src/main/java/moheng/member/domain/SocialType.java
+++ b/backend/src/main/java/moheng/member/domain/SocialType.java
@@ -8,14 +8,14 @@ import java.util.Optional;
 public enum SocialType {
     KAKAO, GOOGLE;
 
-    public static boolean isMatches(SocialType input) {
+    public static boolean isMatches(final SocialType input) {
         for(SocialType type : SocialType.values()) {
             if(type == input) return true;
         }
         return false;
     }
 
-    public static SocialType findByName(String input) {
+    public static SocialType findByName(final String input) {
         return Arrays.stream(SocialType.values())
                 .filter(type -> type.name().equalsIgnoreCase(input))
                 .findFirst()

--- a/backend/src/main/java/moheng/member/dto/request/CheckDuplicateNicknameRequest.java
+++ b/backend/src/main/java/moheng/member/dto/request/CheckDuplicateNicknameRequest.java
@@ -5,7 +5,7 @@ public class CheckDuplicateNicknameRequest {
 
     public CheckDuplicateNicknameRequest() {}
 
-    public CheckDuplicateNicknameRequest(String nickname) {
+    public CheckDuplicateNicknameRequest(final String nickname) {
         this.nickname = nickname;
     }
 

--- a/backend/src/main/java/moheng/member/dto/request/SignUpInterestTripsRequest.java
+++ b/backend/src/main/java/moheng/member/dto/request/SignUpInterestTripsRequest.java
@@ -8,7 +8,7 @@ public class SignUpInterestTripsRequest {
     private SignUpInterestTripsRequest() {
     }
 
-    public SignUpInterestTripsRequest(List<Long> contentIds) {
+    public SignUpInterestTripsRequest(final List<Long> contentIds) {
         this.contentIds = contentIds;
     }
 

--- a/backend/src/main/java/moheng/member/dto/request/SignUpLiveInfoRequest.java
+++ b/backend/src/main/java/moheng/member/dto/request/SignUpLiveInfoRequest.java
@@ -8,7 +8,7 @@ public class SignUpLiveInfoRequest {
     private SignUpLiveInfoRequest() {
     }
 
-    public SignUpLiveInfoRequest(List<String> liveInfoNames) {
+    public SignUpLiveInfoRequest(final List<String> liveInfoNames) {
         this.liveInfoNames = liveInfoNames;
     }
 

--- a/backend/src/main/java/moheng/member/dto/request/SignUpProfileRequest.java
+++ b/backend/src/main/java/moheng/member/dto/request/SignUpProfileRequest.java
@@ -10,7 +10,8 @@ public class SignUpProfileRequest {
     private final GenderType genderType;
     private final String profileImageUrl;
 
-    public SignUpProfileRequest(String nickname, LocalDate birthday, GenderType genderType, String profileImageUrl) {
+    public SignUpProfileRequest(final String nickname, final LocalDate birthday,
+                                final GenderType genderType, final String profileImageUrl) {
         this.nickname = nickname;
         this.birthday = birthday;
         this.genderType = genderType;

--- a/backend/src/main/java/moheng/member/dto/request/UpdateProfileRequest.java
+++ b/backend/src/main/java/moheng/member/dto/request/UpdateProfileRequest.java
@@ -10,7 +10,8 @@ public class UpdateProfileRequest {
     private final GenderType genderType;
     private final String profileImageUrl;
 
-    public UpdateProfileRequest(String nickname, LocalDate birthday, GenderType genderType, String profileImageUrl) {
+    public UpdateProfileRequest(final String nickname, final LocalDate birthday,
+                                final GenderType genderType, final String profileImageUrl) {
         this.nickname = nickname;
         this.birthday = birthday;
         this.genderType = genderType;

--- a/backend/src/main/java/moheng/member/exception/InvalidBirthdayException.java
+++ b/backend/src/main/java/moheng/member/exception/InvalidBirthdayException.java
@@ -1,7 +1,7 @@
 package moheng.member.exception;
 
 public class InvalidBirthdayException extends RuntimeException {
-    public InvalidBirthdayException(String message) {
+    public InvalidBirthdayException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/member/exception/InvalidGenderFormatException.java
+++ b/backend/src/main/java/moheng/member/exception/InvalidGenderFormatException.java
@@ -1,7 +1,7 @@
 package moheng.member.exception;
 
 public class InvalidGenderFormatException extends RuntimeException {
-    public InvalidGenderFormatException(String message) {
+    public InvalidGenderFormatException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/member/exception/InvalidNicknameFormatException.java
+++ b/backend/src/main/java/moheng/member/exception/InvalidNicknameFormatException.java
@@ -1,7 +1,7 @@
 package moheng.member.exception;
 
 public class InvalidNicknameFormatException extends RuntimeException {
-    public InvalidNicknameFormatException(String message) {
+    public InvalidNicknameFormatException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/member/exception/NoExistSocialTypeException.java
+++ b/backend/src/main/java/moheng/member/exception/NoExistSocialTypeException.java
@@ -1,7 +1,7 @@
 package moheng.member.exception;
 
 public class NoExistSocialTypeException extends RuntimeException {
-    public NoExistSocialTypeException(String message) {
+    public NoExistSocialTypeException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/member/exception/ShortContentidsSizeException.java
+++ b/backend/src/main/java/moheng/member/exception/ShortContentidsSizeException.java
@@ -1,7 +1,7 @@
 package moheng.member.exception;
 
 public class ShortContentidsSizeException extends RuntimeException {
-    public ShortContentidsSizeException(String message) {
+    public ShortContentidsSizeException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    public MemberController(MemberService memberService) {
+    public MemberController(final MemberService memberService) {
         this.memberService = memberService;
     }
 

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -10,7 +10,7 @@ import moheng.member.dto.response.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/member")
+@RequestMapping("/api/member")
 @RestController
 public class MemberController {
     private final MemberService memberService;

--- a/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
+++ b/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
@@ -130,7 +130,6 @@ public class RecommendTripService {
     public void createRecommendTrip(final long memberId, final RecommendTripCreateRequest request) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(NoExistMemberException::new);
-
         final Trip trip = tripRepository.findById(request.getTripId())
                 .orElseThrow(NoExistTripException::new);
 

--- a/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
+++ b/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
@@ -111,7 +111,6 @@ public class RecommendTripService {
     private List<Trip> filterTripsByLiveinformation(final RecommendTripsByVisitedLogsResponse recommendTripsByVisitedLogsResponse, final Long memberId) {
         final List<Trip> trips = tripRepository.findTripsByContentIds(recommendTripsByVisitedLogsResponse.getContentIds());
         final List<LiveInformation> memberLiveInformations = memberLiveInformationRepository.findLiveInformationsByMemberId(memberId);
-        List<Trip> trips1 = filterTripsByMemberInformation(trips, memberLiveInformations);
         return filterTripsByMemberInformation(trips, memberLiveInformations);
     }
 

--- a/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
+++ b/backend/src/main/java/moheng/recommendtrip/application/RecommendTripService.java
@@ -108,7 +108,6 @@ public class RecommendTripService {
         }
     }
 
-
     private List<Trip> filterTripsByLiveinformation(final RecommendTripsByVisitedLogsResponse recommendTripsByVisitedLogsResponse, final Long memberId) {
         final List<Trip> trips = tripRepository.findTripsByContentIds(recommendTripsByVisitedLogsResponse.getContentIds());
         final List<LiveInformation> memberLiveInformations = memberLiveInformationRepository.findLiveInformationsByMemberId(memberId);

--- a/backend/src/main/java/moheng/recommendtrip/domain/RecommendTrip.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/RecommendTrip.java
@@ -24,9 +24,6 @@ public class RecommendTrip extends BaseEntity {
     @Column(name = "rank")
     private Long rank;
 
-    @Column(name = "visited_count")
-    private Long visitedCount;
-
     protected RecommendTrip() {
     }
 

--- a/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
@@ -13,9 +13,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RecommendTripRepository extends JpaRepository<RecommendTrip, Long> {
-    @Query("SELECT new moheng.keyword.dto.RecommendTripResponse(rt.trip.contentId, rt.visitedCount) FROM RecommendTrip rt WHERE rt.member.id = :memberId")
-    List<RecommendTripResponse> findVisitedCountAndTripContentIdByMemberId(@Param("memberId") final Long memberId);
-
     List<RecommendTrip> findAllByMemberId(final Long memberId);
 
     List<RecommendTrip> findTop10ByMember(Member member);

--- a/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/RecommendTripRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface RecommendTripRepository extends JpaRepository<RecommendTrip, Long> {
     List<RecommendTrip> findAllByMemberId(final Long memberId);
 
-    List<RecommendTrip> findTop10ByMember(Member member);
+    List<RecommendTrip> findTop10ByMember(final Member member);
 
     boolean existsByMemberAndTrip(final Member member, final Trip trip);
 

--- a/backend/src/main/java/moheng/recommendtrip/dto/RecommendTripCreateRequest.java
+++ b/backend/src/main/java/moheng/recommendtrip/dto/RecommendTripCreateRequest.java
@@ -6,7 +6,7 @@ public class RecommendTripCreateRequest {
     private RecommendTripCreateRequest() {
     }
 
-    public RecommendTripCreateRequest(Long tripId) {
+    public RecommendTripCreateRequest(final Long tripId) {
         this.tripId = tripId;
     }
 

--- a/backend/src/main/java/moheng/recommendtrip/presentation/RecommendTripController.java
+++ b/backend/src/main/java/moheng/recommendtrip/presentation/RecommendTripController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RequestMapping("/recommend")
+@RequestMapping("/api/recommend")
 @RestController
 public class RecommendTripController {
     private final RecommendTripService recommendTripService;

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -35,7 +35,6 @@ public class TripService {
     private final MemberRepository memberRepository;
     private final MemberTripRepository memberTripRepository;
     private final TripKeywordRepository tripKeywordRepository;
-    private final TripLiveInformationRepository tripLiveInformationRepository;
     private final LiveInformationRepository liveInformationRepository;
 
     public TripService(final TripRepository tripRepository,
@@ -51,7 +50,6 @@ public class TripService {
         this.memberTripRepository = memberTripRepository;
         this.tripKeywordRepository = tripKeywordRepository;
         this.saveRecommendTripStrategyProvider = saveRecommendTripStrategyProvider;
-        this.tripLiveInformationRepository = tripLiveInformationRepository;
         this.liveInformationRepository = liveInformationRepository;
     }
 

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -66,7 +66,7 @@ public class TripService {
         final List<Trip> filteredSimilarTrips = new ArrayList<>();
         long page = 1L;
         while(filteredSimilarTrips.size() < SIMILAR_TRIPS_COUNT) {
-            final FindSimilarTripWithContentIdResponses similarTripWithContentIdResponses = externalSimilarTripModelClient.findSimilarTrips(trip.getContentId());
+            final FindSimilarTripWithContentIdResponses similarTripWithContentIdResponses = externalSimilarTripModelClient.findSimilarTrips(trip.getContentId(), page);
             final List<Trip> filteredTripsByLiveInformation = findFilteredTripsByLiveInformation(trip, similarTripWithContentIdResponses.getContentIds());
             filteredSimilarTrips.addAll(filteredTripsByLiveInformation);
             page++;

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -41,8 +41,10 @@ public class TripService {
                        final ExternalSimilarTripModelClient externalSimilarTripModelClient,
                        final RecommendTripRepository recommendTripRepository,
                        final MemberRepository memberRepository,
-                       final MemberTripRepository memberTripRepository, TripKeywordRepository tripKeywordRepository,
-                       final SaveRecommendTripStrategyProvider saveRecommendTripStrategyProvider, TripLiveInformationRepository tripLiveInformationRepository, LiveInformationRepository liveInformationRepository) {
+                       final MemberTripRepository memberTripRepository,
+                       final TripKeywordRepository tripKeywordRepository,
+                       final SaveRecommendTripStrategyProvider saveRecommendTripStrategyProvider,
+                       final LiveInformationRepository liveInformationRepository) {
         this.tripRepository = tripRepository;
         this.externalSimilarTripModelClient = externalSimilarTripModelClient;
         this.recommendTripRepository = recommendTripRepository;

--- a/backend/src/main/java/moheng/trip/domain/ExternalSimilarTripModelClient.java
+++ b/backend/src/main/java/moheng/trip/domain/ExternalSimilarTripModelClient.java
@@ -4,5 +4,5 @@ import moheng.trip.dto.FindSimilarTripWithContentIdResponses;
 import moheng.trip.dto.SimilarTripResponses;
 
 public interface ExternalSimilarTripModelClient {
-    FindSimilarTripWithContentIdResponses findSimilarTrips(long contentId);
+    FindSimilarTripWithContentIdResponses findSimilarTrips(final long contentId, final long page);
 }

--- a/backend/src/main/java/moheng/trip/domain/Trip.java
+++ b/backend/src/main/java/moheng/trip/domain/Trip.java
@@ -62,19 +62,19 @@ public class Trip extends BaseEntity {
         this.visitedCount = visitedCount;
     }
 
-    void validateName(String name) {
+    void validateName(final String name) {
         if(name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH ) {
             throw new InvalidTripNameException("여행지 이름의 길이는 100자 이하, 2자 이상만 허용됩니다.");
         }
     }
 
-    void validatePlaceName(String placeName) {
+    void validatePlaceName(final String placeName) {
         if(placeName.length() < MIN_NAME_LENGTH || placeName.length() > MAX_NAME_LENGTH ) {
             throw new InvalidTripNameException("여행지 장소명의 길이는 100자 이하, 2자 이상만 허용됩니다.");
         }
     }
 
-    void validateDescription(String description) {
+    void validateDescription(final String description) {
         if(description.isEmpty() || description == null) {
             throw new InvalidTripDescriptionException("여행지 설명은 비어있을 수 없습니다.");
         }
@@ -95,12 +95,10 @@ public class Trip extends BaseEntity {
         return contentId;
     }
 
-    @Generated
     public Long getId() {
         return id;
     }
 
-    @Generated
     public String getDescription() {
         return description;
     }
@@ -109,12 +107,10 @@ public class Trip extends BaseEntity {
         return placeName;
     }
 
-    @Generated
     public String getTripImageUrl() {
         return tripImageUrl;
     }
 
-    @Generated
     public Long getVisitedCount() {
         return visitedCount;
     }

--- a/backend/src/main/java/moheng/trip/domain/TripRepository.java
+++ b/backend/src/main/java/moheng/trip/domain/TripRepository.java
@@ -16,4 +16,12 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
 
     @Query("SELECT t FROM Trip t WHERE t.contentId IN :contentIds")
     List<Trip> findTripsByContentIds(final List<Long> contentIds);
+
+    @Query("SELECT t FROM Trip t " +
+            "JOIN TripLiveInformation tl ON t.id = tl.trip.id " +
+            "JOIN LiveInformation li ON tl.liveInformation.id = li.id " +
+            "WHERE li.id = :liveInformationId " +
+            "AND t.contentId IN :contentIds")
+    List<Trip> findFilteredTripsByLiveInformation(@Param("liveInformationId") final Long liveInformationId,
+                                                  @Param("contentIds") final List<Long> contentIds);
 }

--- a/backend/src/main/java/moheng/trip/domain/TripRepository.java
+++ b/backend/src/main/java/moheng/trip/domain/TripRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
-    Optional<Trip> findByContentId(Long contentId);
+    Optional<Trip> findByContentId(final Long contentId);
     List<Trip> findTop30ByOrderByVisitedCountDesc();
 
     @Query("SELECT k.name FROM Keyword k WHERE k.id IN :keywordIds")

--- a/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
+++ b/backend/src/main/java/moheng/trip/domain/recommendstrategy/AppendRecommendTripStrategy.java
@@ -19,7 +19,7 @@ public class AppendRecommendTripStrategy implements RecommendTripStrategy {
     }
 
     @Override
-    public void execute(Trip trip, Member member, List<RecommendTrip> recommendTrips) {
+    public void execute(final Trip trip, final Member member, final List<RecommendTrip> recommendTrips) {
         final long highestRank = findHighestRecommendTripRank(recommendTrips);
         recommendTripRepository.save(new RecommendTrip(trip, member, highestRank + 1));
     }

--- a/backend/src/main/java/moheng/trip/dto/SimilarTripRequests.java
+++ b/backend/src/main/java/moheng/trip/dto/SimilarTripRequests.java
@@ -2,15 +2,21 @@ package moheng.trip.dto;
 
 public class SimilarTripRequests {
     private Long contentId;
+    private Long page;
 
     private SimilarTripRequests() {
     }
 
-    public SimilarTripRequests(final Long contentId) {
+    public SimilarTripRequests(final Long contentId, final Long page) {
         this.contentId = contentId;
+        this.page = page;
     }
 
     public Long getContentId() {
         return contentId;
+    }
+
+    public Long getPage() {
+        return page;
     }
 }

--- a/backend/src/main/java/moheng/trip/dto/SimilarTripResponses.java
+++ b/backend/src/main/java/moheng/trip/dto/SimilarTripResponses.java
@@ -15,11 +15,11 @@ public class SimilarTripResponses {
     private SimilarTripResponses() {
     }
 
-    public SimilarTripResponses(List<Trip> trips, List<TripKeyword> tripKeywords) {
+    public SimilarTripResponses(final List<Trip> trips, final List<TripKeyword> tripKeywords) {
         this.findTripResponses = toResponse(trips, tripKeywords);
     }
 
-    private List<FindTripResponse> toResponse(List<Trip> trips, List<TripKeyword> tripKeywords) {
+    private List<FindTripResponse> toResponse(final List<Trip> trips, final List<TripKeyword> tripKeywords) {
         Map<Trip, List<String>> tripKeywordMap = new HashMap<>();
         for (TripKeyword tripKeyword : tripKeywords) {
             Trip trip = tripKeyword.getTrip();

--- a/backend/src/main/java/moheng/trip/dto/TripCreateRequest.java
+++ b/backend/src/main/java/moheng/trip/dto/TripCreateRequest.java
@@ -10,7 +10,8 @@ public class TripCreateRequest {
     private TripCreateRequest() {
     }
 
-    public TripCreateRequest(String name, String placeName, Long contentId, String description, String tripImageUrl) {
+    public TripCreateRequest(final String name, final String placeName, final Long contentId,
+                             final String description, final String tripImageUrl) {
         this.name = name;
         this.placeName = placeName;
         this.contentId = contentId;

--- a/backend/src/main/java/moheng/trip/exception/InvalidRecommendTripRankException.java
+++ b/backend/src/main/java/moheng/trip/exception/InvalidRecommendTripRankException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class InvalidRecommendTripRankException extends RuntimeException {
-    public InvalidRecommendTripRankException(String message) {
+    public InvalidRecommendTripRankException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/trip/exception/InvalidTripDescriptionException.java
+++ b/backend/src/main/java/moheng/trip/exception/InvalidTripDescriptionException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class InvalidTripDescriptionException extends RuntimeException {
-    public InvalidTripDescriptionException(String message) {
+    public InvalidTripDescriptionException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/trip/exception/InvalidTripNameException.java
+++ b/backend/src/main/java/moheng/trip/exception/InvalidTripNameException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class InvalidTripNameException extends RuntimeException{
-    public InvalidTripNameException(String message) {
+    public InvalidTripNameException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripException.java
+++ b/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class NoExistRecommendTripException extends RuntimeException {
-    public NoExistRecommendTripException(String message) {
+    public NoExistRecommendTripException(final String message) {
         super(message);
     }
 }

--- a/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripStrategyException.java
+++ b/backend/src/main/java/moheng/trip/exception/NoExistRecommendTripStrategyException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class NoExistRecommendTripStrategyException extends RuntimeException {
-    public NoExistRecommendTripStrategyException(String message) {
+    public NoExistRecommendTripStrategyException(final String message) {
         super(message);
     }
 

--- a/backend/src/main/java/moheng/trip/exception/NoExistTripException.java
+++ b/backend/src/main/java/moheng/trip/exception/NoExistTripException.java
@@ -1,7 +1,7 @@
 package moheng.trip.exception;
 
 public class NoExistTripException extends RuntimeException {
-    public NoExistTripException(String message) {
+    public NoExistTripException(final String message) {
        super(message);
     }
 

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @Component
 public class ExternalAiSimilarTripModelClient implements ExternalSimilarTripModelClient {
-    private static final String SIMILAR_TRIP_LIST_REQUEST_URL = "http://localhost:8000/{contentId}";
+    private static final String SIMILAR_TRIP_LIST_REQUEST_URL = "http://localhost:8000/{contentId}/{page}";
     private final RestTemplate restTemplate;
 
     public ExternalAiSimilarTripModelClient(final RestTemplate restTemplate) {
@@ -23,13 +23,14 @@ public class ExternalAiSimilarTripModelClient implements ExternalSimilarTripMode
     }
 
     @Override
-    public FindSimilarTripWithContentIdResponses findSimilarTrips(long contentId) {
-        return requestSimilarTrips(new SimilarTripRequests(contentId));
+    public FindSimilarTripWithContentIdResponses findSimilarTrips(final long contentId, final long page) {
+        return requestSimilarTrips(new SimilarTripRequests(contentId, page));
     }
 
     private FindSimilarTripWithContentIdResponses requestSimilarTrips(final SimilarTripRequests request) {
         Map<String, Long> uriPathVariable = new HashMap<>();
         uriPathVariable.put("contentId", request.getContentId());
+        uriPathVariable.put("page", request.getPage());
 
         ResponseEntity<FindSimilarTripWithContentIdResponses> contentIdResponses
                 = restTemplate.getForEntity(SIMILAR_TRIP_LIST_REQUEST_URL, FindSimilarTripWithContentIdResponses.class, uriPathVariable);

--- a/backend/src/main/java/moheng/trip/presentation/TripController.java
+++ b/backend/src/main/java/moheng/trip/presentation/TripController.java
@@ -9,7 +9,7 @@ import moheng.trip.dto.TripCreateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/trip")
+@RequestMapping("/api/trip")
 @RestController
 public class TripController {
     private final TripService tripService;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
 
 logging:
   level:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
 logging:
   level:

--- a/backend/src/test/java/moheng/acceptance/RecommendTripAcceptenceTest.java
+++ b/backend/src/test/java/moheng/acceptance/RecommendTripAcceptenceTest.java
@@ -82,7 +82,7 @@ public class RecommendTripAcceptenceTest extends AcceptanceTestConfig {
         ExtractableResponse<Response> resultResponse = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessTokenResponse.getAccessToken())
-                .when().get("/recommend")
+                .when().get("/api/recommend")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/TripAcceptenceTest.java
+++ b/backend/src/test/java/moheng/acceptance/TripAcceptenceTest.java
@@ -102,7 +102,7 @@ public class TripAcceptenceTest extends AcceptanceTestConfig {
         ExtractableResponse<Response> resultResponse = RestAssured.given().log().all()
                 .auth().oauth2(accessTokenResponse.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/trip/find/{tripId}", 1L)
+                .when().get("/api/trip/find/{tripId}", 1L)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/TripAcceptenceTest.java
+++ b/backend/src/test/java/moheng/acceptance/TripAcceptenceTest.java
@@ -3,6 +3,7 @@ package moheng.acceptance;
 import static moheng.acceptance.fixture.RecommendTripAcceptenceFixture.*;
 import static moheng.acceptance.fixture.AuthAcceptanceFixture.자체_토큰을_생성한다;
 import static moheng.acceptance.fixture.KeywordAcceptenceFixture.키워드를_생성한다;
+import static moheng.acceptance.fixture.LiveInfoAcceptenceFixture.*;
 import static moheng.acceptance.fixture.TripKeywordAcceptenceFixture.*;
 import static moheng.acceptance.fixture.TripAcceptenceFixture.*;
 import static moheng.acceptance.fixture.HttpStatusAcceptenceFixture.상태코드_200이_반환된다;
@@ -65,7 +66,7 @@ public class TripAcceptenceTest extends AcceptanceTestConfig {
         });
     }
 
-    @DisplayName("현재 여행지를 비슷한 여행지와 함께 조회하고 상태코드 200을 리턴한다.")
+    @DisplayName("현재 여행지를 비슷한 여행지 10개와 함께 조회하고 상태코드 200을 리턴한다.")
     @Test
     void 현재_여행지를_비슷한_여행지와_함께_조회하고_상태코드_200을_리턴한다() {
         // given
@@ -73,11 +74,25 @@ public class TripAcceptenceTest extends AcceptanceTestConfig {
         AccessTokenResponse accessTokenResponse = loginResponse.as(AccessTokenResponse.class);
 
         여행지를_생성한다("롯데월드1", 1L); 여행지를_생성한다("롯데월드2", 2L); 여행지를_생성한다("롯데월드3", 3L);
+        여행지를_생성한다("롯데월드4", 4L); 여행지를_생성한다("롯데월드4", 5L); 여행지를_생성한다("롯데월드6", 6L);
+        여행지를_생성한다("롯데월드7", 7L); 여행지를_생성한다("롯데월드8", 8L); 여행지를_생성한다("롯데월드9", 9L);
+        여행지를_생성한다("롯데월드10", 10L);
+
         키워드를_생성한다("키워드1"); 키워드를_생성한다("키워드2"); 키워드를_생성한다("키워드3");
-        여행지_키워드를_생성한다(1L, 1L);
-        여행지_키워드를_생성한다(2L, 2L);
-        여행지_키워드를_생성한다(2L, 3L);
-        여행지_키워드를_생성한다(3L, 3L);
+
+        여행지_키워드를_생성한다(1L, 1L); 여행지_키워드를_생성한다(2L, 2L);
+        여행지_키워드를_생성한다(2L, 3L); 여행지_키워드를_생성한다(3L, 3L);
+        여행지_키워드를_생성한다(3L, 4L); 여행지_키워드를_생성한다(3L, 5L);
+        여행지_키워드를_생성한다(3L, 6L); 여행지_키워드를_생성한다(3L, 7L);
+        여행지_키워드를_생성한다(3L, 8L); 여행지_키워드를_생성한다(3L, 9L);
+        여행지_키워드를_생성한다(3L, 10L); 여행지_키워드를_생성한다(2L, 10L);
+
+        생활정보를_생성한다("생활정보1");
+        여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 1L, 1L); 여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 2L, 1L);
+        여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 3L, 1L); 여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 4L, 1L);
+        여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 5L, 1L); 여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 6L, 1L);
+        여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 7L, 1L); 여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 8L, 1L);
+        여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 9L, 1L); 여행지의_생활정보를_생성한다(accessTokenResponse.getAccessToken(), 10L, 1L);
 
         선호_여행지를_선택한다(1L, accessTokenResponse.getAccessToken());
         선호_여행지를_선택한다(2L, accessTokenResponse.getAccessToken());
@@ -96,7 +111,7 @@ public class TripAcceptenceTest extends AcceptanceTestConfig {
 
         // then
         assertAll(() -> {
-            assertThat(findTripWithSimilarTripsResponse.getSimilarTripResponses().getFindTripResponses()).hasSize(3);
+            assertThat(findTripWithSimilarTripsResponse.getSimilarTripResponses().getFindTripResponses()).hasSize(10);
             assertThat(findTripWithSimilarTripsResponse.getFindTripResponse()).isNotNull();
             assertThat(resultResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
         });

--- a/backend/src/test/java/moheng/acceptance/fixture/AuthAcceptanceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/AuthAcceptanceFixture.java
@@ -18,7 +18,7 @@ public class AuthAcceptanceFixture {
     public static ExtractableResponse<Response> OAuth_인증_URI를_생성한다(final String oauthProvider) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/auth/{provider}/link", oauthProvider)
+                .when().get("/api/auth/{provider}/link", oauthProvider)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -28,7 +28,7 @@ public class AuthAcceptanceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new TokenRequest(code))
-                .when().post("/auth/{oAuthProvider}/login", oauthProvider)
+                .when().post("/api/auth/{oAuthProvider}/login", oauthProvider)
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract();
@@ -38,7 +38,7 @@ public class AuthAcceptanceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(refreshToken)
-                .when().post("/auth/extend/login")
+                .when().post("/api/auth/extend/login")
                 .then().log().all()
                 .extract();
     }
@@ -48,7 +48,7 @@ public class AuthAcceptanceFixture {
                 .auth().oauth2(accessTokenResponse.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(refreshToken)
-                .when().delete("/auth/logout")
+                .when().delete("/api/auth/logout")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -59,7 +59,7 @@ public class AuthAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessTokenResponse.getAccessToken())
                 .body(new SignUpLiveInfoRequest(List.of("생활정보1", "생활정보2")))
-                .when().post("/member/signup/liveinfo")
+                .when().post("/api/member/signup/liveinfo")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -70,7 +70,7 @@ public class AuthAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessTokenResponse.getAccessToken())
                 .body(new SignUpInterestTripsRequest(List.of(1L, 2L, 3L, 4L, 5L)))
-                .when().post("/member/signup/trip")
+                .when().post("/api/member/signup/trip")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/KeywordAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/KeywordAcceptenceFixture.java
@@ -13,7 +13,7 @@ public class KeywordAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new KeywordCreateRequest(name))
-                .when().post("/keyword")
+                .when().post("/api/keyword")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -24,7 +24,7 @@ public class KeywordAcceptenceFixture {
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(tripsByKeyWordsRequest)
-                .when().post("/keyword/trip/recommend")
+                .when().post("/api/keyword/trip/recommend")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -33,7 +33,7 @@ public class KeywordAcceptenceFixture {
     public static ExtractableResponse<Response> 랜덤_키워드_리스트로_여행지를_추천받는다() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/keyword/random/trip")
+                .when().get("/api/keyword/random/trip")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/LiveInfoAcceptenceFixture.java
@@ -13,7 +13,7 @@ public class LiveInfoAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new LiveInformationCreateRequest(name))
-                .when().post("/live/info")
+                .when().post("/api/live/info")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -22,7 +22,7 @@ public class LiveInfoAcceptenceFixture {
     public static ExtractableResponse<Response> 모든_생활정보를_찾는다() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/live/info/all")
+                .when().get("/api/live/info/all")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -32,7 +32,7 @@ public class LiveInfoAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessTokenResponse.getAccessToken())
-                .when().get("/live/info/member")
+                .when().get("/api/live/info/member")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/MemberAcceptanceFixture.java
@@ -18,7 +18,7 @@ public class MemberAcceptanceFixture {
         return RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/member/me")
+                .when().get("/api/member/me")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -29,7 +29,7 @@ public class MemberAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
                 .body(new SignUpProfileRequest("devhaon", LocalDate.of(2000, 1, 1), GenderType.MEN, "https://profile-image.com"))
-                .when().post("/member/signup/profile")
+                .when().post("/api/member/signup/profile")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -40,7 +40,7 @@ public class MemberAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
                 .body(new CheckDuplicateNicknameRequest("devhaon"))
-                .when().post("/member/check/nickname")
+                .when().post("/api/member/check/nickname")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -51,7 +51,7 @@ public class MemberAcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
                 .body(new UpdateProfileRequest("devhaon", LocalDate.of(2000, 1, 1), GenderType.MEN, "https://image.com"))
-                .when().put("/member/profile")
+                .when().put("/api/member/profile")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/MemberLiveInfoAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/MemberLiveInfoAcceptenceFixture.java
@@ -16,7 +16,7 @@ public class MemberLiveInfoAcceptenceFixture {
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new UpdateMemberLiveInformationRequest(List.of(1L, 2L)))
-                .when().put("/live/info/member")
+                .when().put("/api/live/info/member")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/RecommendTripAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/RecommendTripAcceptenceFixture.java
@@ -12,7 +12,7 @@ public class RecommendTripAcceptenceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
                 .body(new RecommendTripCreateRequest(tripId))
-                .when().post("/recommend")
+                .when().post("/api/recommend")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/TripAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/TripAcceptenceFixture.java
@@ -17,7 +17,7 @@ public class TripAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new TripCreateRequest(name, "서울특별시 송파구", contentId, "롯데월드 관련 설명", "https://lotte-world.png"))
-                .when().post("/trip")
+                .when().post("/api/trip")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -26,7 +26,7 @@ public class TripAcceptenceFixture {
     public static ExtractableResponse<Response> 상위_30개_여행지를_찾는다() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/trip/find/interested")
+                .when().get("/api/trip/find/interested")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
@@ -36,7 +36,7 @@ public class TripAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
-                .when().post("/trip/member/{tripId}", tripId)
+                .when().post("/api/trip/member/{tripId}", tripId)
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();
@@ -46,7 +46,7 @@ public class TripAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(accessToken)
-                .when().post("/live/info/trip/{tripId}/{liveInfoId}", tripId, liveInfoId)
+                .when().post("/api/live/info/trip/{tripId}/{liveInfoId}", tripId, liveInfoId)
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/acceptance/fixture/TripKeywordAcceptenceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/TripKeywordAcceptenceFixture.java
@@ -11,7 +11,7 @@ public class TripKeywordAcceptenceFixture {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new TripKeywordCreateRequest(tripId, keywordId))
-                .when().post("/keyword/trip")
+                .when().post("/api/keyword/trip")
                 .then().log().all()
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();

--- a/backend/src/test/java/moheng/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/moheng/auth/presentation/AuthControllerTest.java
@@ -39,7 +39,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         given(authService.generateUri(anyString())).willReturn("URI");
 
         // when, then
-        mockMvc.perform(get("/auth/{oAuthProvider}/link", "KAKAO"))
+        mockMvc.perform(get("/api/auth/{oAuthProvider}/link", "KAKAO"))
                 .andDo(print())
                 .andDo(document("auth/generate/link",
                         preprocessRequest(prettyPrint()),
@@ -57,7 +57,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         given(authService.generateTokenWithCode(any(), any())).willReturn(토큰_응답());
 
         // when, then
-        mockMvc.perform(post("/auth/{oAuthProvider}/login", "KAKAO")
+        mockMvc.perform(post("/api/auth/{oAuthProvider}/login", "KAKAO")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(토큰_생성_요청())))
@@ -83,7 +83,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         given(authService.generateTokenWithCode(any(), any())).willThrow(new InvalidOAuthServiceException("카카오 OAuth 소셜 로그인 서버에 예기치 못한 오류가 발생했습니다."));
 
         // when, then
-        mockMvc.perform(post("/auth/{oAuthProvider}/token", "KAKAO")
+        mockMvc.perform(post("/api/auth/{oAuthProvider}/token", "KAKAO")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(토큰_생성_요청())))
@@ -103,7 +103,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         given(authService.generateRenewalAccessToken(any())).willReturn(토큰_갱신_응답());
 
         // when, then
-        mockMvc.perform(post("/auth/extend/login")
+        mockMvc.perform(post("/api/auth/extend/login")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .cookie(토큰_갱신_요청()))
@@ -130,7 +130,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         given(authService.generateRenewalAccessToken(any())).willThrow(new InvalidTokenException("변조되었거나 만료된 토큰 입니다."));
 
         // when, then
-        mockMvc.perform(post("/auth/extend/login")
+        mockMvc.perform(post("/api/auth/extend/login")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(토큰_갱신_요청())
@@ -154,7 +154,7 @@ public class AuthControllerTest extends ControllerTestConfig {
         doNothing().when(authService).removeRefreshToken(any());
 
         // when, then
-        mockMvc.perform(delete("/auth/logout")
+        mockMvc.perform(delete("/api/auth/logout")
                         .header("Authorization", "Bearer aaaaaaaa.bbbbbbbb.cccccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/moheng/config/stub/StubSimilarTripModelClient.java
+++ b/backend/src/test/java/moheng/config/stub/StubSimilarTripModelClient.java
@@ -9,7 +9,7 @@ public class StubSimilarTripModelClient implements ExternalSimilarTripModelClien
     private static final List<Long> contentIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L);
 
     @Override
-    public FindSimilarTripWithContentIdResponses findSimilarTrips(long contentId) {
+    public FindSimilarTripWithContentIdResponses findSimilarTrips(final long contentId, final long page) {
         return new FindSimilarTripWithContentIdResponses(contentIds);
     }
 }

--- a/backend/src/test/java/moheng/config/stub/StubSimilarTripModelClient.java
+++ b/backend/src/test/java/moheng/config/stub/StubSimilarTripModelClient.java
@@ -6,7 +6,7 @@ import moheng.trip.dto.FindSimilarTripWithContentIdResponses;
 import java.util.List;
 
 public class StubSimilarTripModelClient implements ExternalSimilarTripModelClient {
-    private static final List<Long> contentIds = List.of(1L, 2L, 3L);
+    private static final List<Long> contentIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L);
 
     @Override
     public FindSimilarTripWithContentIdResponses findSimilarTrips(long contentId) {

--- a/backend/src/test/java/moheng/keyword/presentation/KeywordControllerTest.java
+++ b/backend/src/test/java/moheng/keyword/presentation/KeywordControllerTest.java
@@ -34,7 +34,7 @@ public class KeywordControllerTest extends ControllerTestConfig {
         given(keywordService.findRecommendTripsByKeywords(any())).willReturn(키워드_기반_추천_여행지_응답());
 
         // when, then
-        mockMvc.perform(post("/keyword/trip/recommend")
+        mockMvc.perform(post("/api/keyword/trip/recommend")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -69,7 +69,7 @@ public class KeywordControllerTest extends ControllerTestConfig {
         doNothing().when(keywordService).createKeyword(any());
 
         // when, then
-        mockMvc.perform(post("/keyword")
+        mockMvc.perform(post("/api/keyword")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -86,7 +86,7 @@ public class KeywordControllerTest extends ControllerTestConfig {
         doNothing().when(keywordService).createTripKeyword(any());
 
         // when, then
-        mockMvc.perform(post("/keyword/trip")
+        mockMvc.perform(post("/api/keyword/trip")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(여행지_키워드_생성_요청()))
@@ -103,7 +103,7 @@ public class KeywordControllerTest extends ControllerTestConfig {
                 .willReturn(키워드_기반_추천_여행지_응답());
 
         // when, then
-        mockMvc.perform(get("/keyword/random/trip")
+        mockMvc.perform(get("/api/keyword/random/trip")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                 )

--- a/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/LiveInformationControllerTest.java
@@ -38,7 +38,7 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
                 ));
 
         // when, then
-        mockMvc.perform(get("/live/info/all")
+        mockMvc.perform(get("/api/live/info/all")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
         )
@@ -63,7 +63,7 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
         doNothing().when(liveInformationService).createLiveInformation(any());
 
         // when, then
-        mockMvc.perform(post("/live/info")
+        mockMvc.perform(post("/api/live/info")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(비어있는_생활정보로_회원가입_요청()))
@@ -79,7 +79,7 @@ public class LiveInformationControllerTest extends ControllerTestConfig {
         doNothing().when(liveInformationService).createTripLiveInformation(anyLong(), anyLong());
 
         // when, then
-        mockMvc.perform(post("/live/info/trip/{tripId}/{liveInfoId}", 1L, 1L)
+        mockMvc.perform(post("/api/live/info/trip/{tripId}/{liveInfoId}", 1L, 1L)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())

--- a/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
+++ b/backend/src/test/java/moheng/liveinformation/presentation/MemberLiveInfoControllerTest.java
@@ -35,7 +35,7 @@ public class MemberLiveInfoControllerTest extends ControllerTestConfig {
                 )));
 
         // when, then
-        mockMvc.perform(get("/live/info/member")
+        mockMvc.perform(get("/api/live/info/member")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -60,7 +60,7 @@ public class MemberLiveInfoControllerTest extends ControllerTestConfig {
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
 
         // when, then
-        mockMvc.perform(put("/live/info/member")
+        mockMvc.perform(put("/api/live/info/member")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -38,7 +38,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberService.findById(anyLong())).willReturn(하온_응답());
 
         // when, then
-        mockMvc.perform(get("/member/me")
+        mockMvc.perform(get("/api/member/me")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -69,7 +69,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
-        mockMvc.perform(post("/member/signup/profile")
+        mockMvc.perform(post("/api/member/signup/profile")
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -103,7 +103,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .when(memberService).checkIsAlreadyExistNickname(anyString());
 
         // when, then
-        mockMvc.perform(post("/member/signup/profile")
+        mockMvc.perform(post("/api/member/signup/profile")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -134,7 +134,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
-        mockMvc.perform(post("/member/check/nickname")
+        mockMvc.perform(post("/api/member/check/nickname")
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -166,7 +166,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .when(memberService).checkIsAlreadyExistNickname(anyString());
 
         // when, then
-        mockMvc.perform(post("/member/check/nickname")
+        mockMvc.perform(post("/api/member/check/nickname")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -195,7 +195,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
 
         // when, then
-        mockMvc.perform(put("/member/profile")
+        mockMvc.perform(put("/api/member/profile")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -227,7 +227,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .when(memberService).updateByProfile(anyLong(), any());
 
         // when, then
-        mockMvc.perform(put("/member/profile")
+        mockMvc.perform(put("/api/member/profile")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -258,7 +258,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         doNothing().when(memberService).signUpByLiveInfo(anyLong(), any());
 
         // when, then
-        mockMvc.perform(post("/member/signup/liveinfo")
+        mockMvc.perform(post("/api/member/signup/liveinfo")
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -286,7 +286,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .when(memberService).signUpByLiveInfo(anyLong(), any());
 
         // when, then
-        mockMvc.perform(post("/member/signup/liveinfo")
+        mockMvc.perform(post("/api/member/signup/liveinfo")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -312,7 +312,7 @@ public class MemberControllerTest extends ControllerTestConfig {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(하온_신규()));
 
         // when, then
-        mockMvc.perform(post("/member/signup/trip")
+        mockMvc.perform(post("/api/member/signup/trip")
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -340,7 +340,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                 .when(memberService).signUpByInterestTrips(anyLong(), any());
 
         // when, then
-        mockMvc.perform(post("/member/signup/trip")
+        mockMvc.perform(post("/api/member/signup/trip")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
+++ b/backend/src/test/java/moheng/recommendtrip/domain/RecommendTripRepositoryTest.java
@@ -31,23 +31,6 @@ public class RecommendTripRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private TripRepository tripRepository;
 
-    @DisplayName("멤버의 선호 여행지 contentId 와 방문횟수를 찾는다.")
-    @Test
-    void 멤버의_선호_여행지_contentId_와_방문횟수를_찾는다() {
-        // given
-        memberRepository.save(하온_기존());
-        Member member = memberRepository.findByEmail(하온_이메일).orElseThrow();
-        tripRepository.save(new Trip("여행지", "장소명", 1L, "설명", "이미지 경로"));
-        Trip trip = tripRepository.findByContentId(1L).get();
-        recommendTripRepository.save(new RecommendTrip(trip, member));
-
-        // when
-        List<RecommendTripResponse> expected = recommendTripRepository.findVisitedCountAndTripContentIdByMemberId(member.getId());
-
-        // then
-        assertThat(expected).hasSize(1);
-    }
-
     @DisplayName("멤버의 선호 여행지를 찾는다.")
     @Test
     void 멤버의_선호_여행지를_찾는다() {

--- a/backend/src/test/java/moheng/recommendtrip/presentation/RecommendTripControllerTest.java
+++ b/backend/src/test/java/moheng/recommendtrip/presentation/RecommendTripControllerTest.java
@@ -33,7 +33,7 @@ public class RecommendTripControllerTest extends ControllerTestConfig {
         doNothing().when(recommendTripService).createRecommendTrip(anyLong(), any());
 
         // when, then
-        mockMvc.perform(post("/recommend")
+        mockMvc.perform(post("/api/recommend")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -51,7 +51,7 @@ public class RecommendTripControllerTest extends ControllerTestConfig {
                 .willReturn(AI_맞춤_추천_여행지_응답());
 
         // when, then
-        mockMvc.perform(get("/recommend")
+        mockMvc.perform(get("/api/recommend")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -81,7 +81,7 @@ public class RecommendTripControllerTest extends ControllerTestConfig {
                 .willThrow(new InvalidAIServerException("AI 서버에 예기치 못한 오류가 발생했습니다."));
 
         // when, then
-        mockMvc.perform(get("/recommend")
+        mockMvc.perform(get("/api/recommend")
                         .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -580,32 +580,39 @@ public class TripServiceTest extends ServiceTestConfig {
     void 가장_낮은_우선순위를_가진_랭크가_10인_신규_선호_여행지를_생성한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        tripService.save(new Trip("여행지11", "서울", 11L, "설명11", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
 
         // when
-        Trip trip11 = tripService.findById(11L);
-        tripService.findWithSimilarOtherTrips(trip11.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
         RecommendTrip recommendTrip = recommendTripRepository.findById(11L).get();
 
         // then

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -251,15 +251,28 @@ public class TripServiceTest extends ServiceTestConfig {
     void 현재_여행지를_조회하면_각_유저에_대한_방문_횟수가_증가한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        Trip trip = tripService.findById(1L);
-        recommendTripRepository.save(new RecommendTrip(trip, member, 1L));
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
         // when
-        tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
         assertThat(recommendTripRepository.findById(1L).get().getRank()).isEqualTo(1L);
@@ -303,14 +316,29 @@ public class TripServiceTest extends ServiceTestConfig {
     void 존재하지_않는_회원이_여행지를_조회하면_예외가_발생한다() {
         // given
         long invalidMemberId = -1L;
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        Trip trip = tripService.findById(1L);
+        Member member = memberRepository.save(하온_기존());
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
         // when, then
-        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(trip.getId(), invalidMemberId))
+        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(currentTrip.getId(), invalidMemberId))
                 .isInstanceOf(NoExistMemberException.class);
     }
 
@@ -336,23 +364,34 @@ public class TripServiceTest extends ServiceTestConfig {
     void 최근_클릭한_여행지가_10개_미만이라면_가장_높은_rank_에_1을_더한_선호_여행지_정보를_생성한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L);
-        Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L);
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L));
-        recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L));
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
 
         // when
-        Trip trip4 = tripService.findById(4L);
-        tripService.findWithSimilarOtherTrips(trip4.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
-        RecommendTrip actual = recommendTripRepository.findById(trip4.getId()).get();
+        RecommendTrip actual = recommendTripRepository.findById(4L).get();
         assertThat(actual.getRank()).isEqualTo(4L);
     }
 
@@ -361,28 +400,39 @@ public class TripServiceTest extends ServiceTestConfig {
     void 최근_클릭한_여행지가_10개라면_기존의_rank를_1씩_감소시키고_rank가_10인_새로운_선호_여행지를_생성한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip2, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip3, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
 
         // when
-        Trip trip = tripService.findById(10L);
-        tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
         assertAll(() -> {
@@ -395,32 +445,39 @@ public class TripServiceTest extends ServiceTestConfig {
     void 현재_여행지를_조회하고_선호_여행지가_10개라면_랭크가_1_감소한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        tripService.save(new Trip("여행지11", "서울", 11L, "설명11", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
 
         // when
-        Trip newVisitTrip = tripService.findById(11L);
-        tripService.findWithSimilarOtherTrips(newVisitTrip.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
         assertAll(() -> {

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -625,35 +625,42 @@ public class TripServiceTest extends ServiceTestConfig {
     void 처음_방문한_여행지라면_방문_횟수는_1이_된다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        tripService.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
-        Trip firstVisitTrip = tripService.findById(11L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
 
         // when
-        tripService.findWithSimilarOtherTrips(firstVisitTrip.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
-        assertThat(memberTripRepository.findByMemberAndTrip(member, firstVisitTrip).getVisitedCount()).isEqualTo(1L);
+        assertThat(memberTripRepository.findByMemberAndTrip(member, currentTrip).getVisitedCount()).isEqualTo(1L);
     }
 
     @DisplayName("이전에 방문했던 여행지라면 방문 횟수가 1이 증가한다.")

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -206,10 +206,39 @@ public class TripServiceTest extends ServiceTestConfig {
         FindTripWithSimilarTripsResponse response = tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
-        assertAll(() -> {
-            assertThat(response.getFindTripResponse()).isNotNull();
-            assertThat(response.getSimilarTripResponses().getFindTripResponses().size()).isEqualTo(10);
-        });
+        assertThat(response.getFindTripResponse()).isNotNull();
+    }
+
+    @DisplayName("비슷한 여행지를 정확히 10개를 찾는다.")
+    @Test
+    void 비슷한_여행지를_정확히_10개를_찾는다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        // when
+        FindTripWithSimilarTripsResponse response = tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
+
+        // then
+        assertThat(response.getSimilarTripResponses().getFindTripResponses()).hasSize(10);
     }
 
 

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -668,29 +668,36 @@ public class TripServiceTest extends ServiceTestConfig {
     void 이전에_방문했던_여행지라면_방문_횟수가_1이_증가한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L);
-        Trip alreadyVisitedTrip = tripService.findById(10L);
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
+
+        Trip alreadyVisitedTrip = tripRepository.findById(10L).get();
         memberTripRepository.save(new MemberTrip(member, alreadyVisitedTrip, 100L));
 
         // when

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -11,6 +11,10 @@ import moheng.keyword.domain.Keyword;
 import moheng.keyword.domain.KeywordRepository;
 import moheng.keyword.domain.TripKeyword;
 import moheng.keyword.domain.TripKeywordRepository;
+import moheng.liveinformation.domain.LiveInformation;
+import moheng.liveinformation.domain.LiveInformationRepository;
+import moheng.liveinformation.domain.TripLiveInformation;
+import moheng.liveinformation.domain.TripLiveInformationRepository;
 import moheng.member.domain.Member;
 import moheng.member.domain.repository.MemberRepository;
 import moheng.member.exception.NoExistMemberException;
@@ -60,6 +64,12 @@ public class TripServiceTest extends ServiceTestConfig {
 
     @Autowired
     private TripRepository tripRepository;
+
+    @Autowired
+    private LiveInformationRepository liveInformationRepository;
+
+    @Autowired
+    private TripLiveInformationRepository tripLiveInformationRepository;
 
     @DisplayName("여행지를 생성한다.")
     @Test
@@ -167,25 +177,38 @@ public class TripServiceTest extends ServiceTestConfig {
         });
     }
 
-    @DisplayName("현재 여행지를 비슷한 여행지와 함께 조회한다.")
+    @DisplayName("현재 여행지를 비슷한 여행지 10개와 함께 조회한다.")
     @Test
     void 현재_여행지를_비슷한_여행지와_함께_조회한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        Trip trip = tripService.findById(1L);
-        recommendTripRepository.save(new RecommendTrip(trip, member, 1L));
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
         // when
-        FindTripWithSimilarTripsResponse response = tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
+        FindTripWithSimilarTripsResponse response = tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
         assertAll(() -> {
             assertThat(response.getFindTripResponse()).isNotNull();
-            assertThat(response.getSimilarTripResponses().getFindTripResponses().size()).isEqualTo(3);
+            assertThat(response.getSimilarTripResponses().getFindTripResponses().size()).isEqualTo(10);
         });
     }
 

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -218,16 +218,29 @@ public class TripServiceTest extends ServiceTestConfig {
     void 현재_여행지를_조회하면_모든_유저에_대한_총_방문_횟수가_증가한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        Trip trip = tripService.findById(1L);
-        recommendTripRepository.save(new RecommendTrip(trip, member, 1L));
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
         // when
-        tripService.findWithSimilarOtherTrips(trip.getId(), member.getId());
-        long expected = tripService.findById(1L).getId();
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
+        long expected = tripService.findById(currentTrip.getId()).getId();
 
         // then
         assertThat(expected).isEqualTo(1L);

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -539,35 +539,39 @@ public class TripServiceTest extends ServiceTestConfig {
     void 기존에_rank가_1등인_선호_여행지가_존재하지_않으면_예외가_발생한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        tripService.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
-        Trip trip11 = tripService.findById(11L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 0L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
 
-        // when
-        Trip trip = tripService.findById(11L);
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 11L));
 
-        // then
-        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(trip.getId(), member.getId()))
+        // when, then
+        assertThatThrownBy(() -> tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId()))
                 .isInstanceOf(NoExistRecommendTripException.class);
     }
 

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -492,37 +492,44 @@ public class TripServiceTest extends ServiceTestConfig {
     void 가장_높았던_랭크를_보유한_선호_여행지를_제거한다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        tripService.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L); Trip trip10 = tripService.findById(10L);
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(trip10, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
 
         // when
-        Trip newVisitTrip = tripService.findById(11L);
-        tripService.findWithSimilarOtherTrips(newVisitTrip.getId(), member.getId());
+        tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
 
         // then
         assertAll(() -> {
             assertThat(recommendTripRepository.findAllByMemberId(member.getId()).size()).isEqualTo(10);
-            assertThat(recommendTripRepository.existsByMemberAndTrip(member, trip1)).isFalse();
+            assertThat(recommendTripRepository.existsByMemberAndTrip(member, trip2)).isFalse();
             assertThat(recommendTripRepository.findById(2L).get().getRank()).isEqualTo(HIGHEST_PRIORITY_RANK);
         });
     }

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -712,28 +712,36 @@ public class TripServiceTest extends ServiceTestConfig {
     void 현재_방문한_여행지가_최근_클릭한_선호_여행지_리스트에_포함된다면_선호_여행지들의_랭크를_수정하지_않는다() {
         // given
         Member member = memberRepository.save(하온_기존());
-        tripService.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
-        tripService.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
-        tripService.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
-        tripService.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
-        tripService.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
-        tripService.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
-        tripService.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
-        tripService.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
-        tripService.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
-        tripService.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
-        Trip trip1 = tripService.findById(1L); Trip trip2 = tripService.findById(2L);
-        Trip trip3 = tripService.findById(3L); Trip trip4 = tripService.findById(4L);
-        Trip trip5 = tripService.findById(5L); Trip trip6 = tripService.findById(6L);
-        Trip trip7 = tripService.findById(7L); Trip trip8 = tripService.findById(8L);
-        Trip trip9 = tripService.findById(9L);
-        Trip alreadyVisitedTrip = tripService.findById(10L);
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
 
-        recommendTripRepository.save(new RecommendTrip(trip1, member, 1L)); recommendTripRepository.save(new RecommendTrip(trip2, member, 2L));
-        recommendTripRepository.save(new RecommendTrip(trip3, member, 3L)); recommendTripRepository.save(new RecommendTrip(trip4, member, 4L));
-        recommendTripRepository.save(new RecommendTrip(trip5, member, 5L)); recommendTripRepository.save(new RecommendTrip(trip6, member, 6L));
-        recommendTripRepository.save(new RecommendTrip(trip7, member, 7L)); recommendTripRepository.save(new RecommendTrip(trip8, member, 8L));
-        recommendTripRepository.save(new RecommendTrip(trip9, member, 9L)); recommendTripRepository.save(new RecommendTrip(alreadyVisitedTrip, member, 10L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
+
+        Trip alreadyVisitedTrip = tripRepository.findById(10L).get();
 
         // when
         tripService.findWithSimilarOtherTrips(alreadyVisitedTrip.getId(), member.getId());

--- a/backend/src/test/java/moheng/trip/domain/TripRepositoryTest.java
+++ b/backend/src/test/java/moheng/trip/domain/TripRepositoryTest.java
@@ -35,4 +35,18 @@ public class TripRepositoryTest extends RepositoryTestConfig {
             }
         });
     }
+
+    @DisplayName("contentId 에 매핑되는 여행지들을 찾는다.")
+    @Test
+    void contentId_에_매핑되는_여행지들을_찾는다() {
+        // given
+        tripRepository.save(new Trip("여행지1", "장소", 1L, "설명", "이미지", 1L));
+        tripRepository.save(new Trip("여행지2", "장소", 2L, "설명", "이미지", 2L));
+        tripRepository.save(new Trip("여행지3", "장소", 3L, "설명", "이미지", 3L));
+        tripRepository.save(new Trip("여행지4", "장소", 4L, "설명", "이미지", 4L));
+        List<Long> contentIds = List.of(1L, 2L, 3L, 4L);
+
+        // when, then
+        assertThat(tripRepository.findTripsByContentIds(contentIds)).hasSize(4);
+    }
 }

--- a/backend/src/test/java/moheng/trip/domain/TripRepositoryTest.java
+++ b/backend/src/test/java/moheng/trip/domain/TripRepositoryTest.java
@@ -6,6 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import moheng.config.slice.RepositoryTestConfig;
+import moheng.liveinformation.domain.LiveInformation;
+import moheng.liveinformation.domain.LiveInformationRepository;
+import moheng.liveinformation.domain.TripLiveInformation;
+import moheng.liveinformation.domain.TripLiveInformationRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +20,12 @@ public class TripRepositoryTest extends RepositoryTestConfig {
 
     @Autowired
     private TripRepository tripRepository;
+
+    @Autowired
+    private LiveInformationRepository liveInformationRepository;
+
+    @Autowired
+    private TripLiveInformationRepository tripLiveInformationRepository;
 
     @DisplayName("방문수 기준 최대 상위 30개의 여행지를 내림차순으로 찾는다.")
     @Test
@@ -45,6 +55,27 @@ public class TripRepositoryTest extends RepositoryTestConfig {
         tripRepository.save(new Trip("여행지3", "장소", 3L, "설명", "이미지", 3L));
         tripRepository.save(new Trip("여행지4", "장소", 4L, "설명", "이미지", 4L));
         List<Long> contentIds = List.of(1L, 2L, 3L, 4L);
+
+        // when, then
+        assertThat(tripRepository.findTripsByContentIds(contentIds)).hasSize(4);
+    }
+
+    @DisplayName("생활정보로 필터링된 여행지 리스트를 찾는다.")
+    @Test
+    void 생활정보로_필터링된_여행지_리스트를_찾는다() {
+        // given
+        Trip trip1 = tripRepository.save(new Trip("여행지1", "장소", 1L, "설명", "이미지", 1L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "장소", 2L, "설명", "이미지", 2L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "장소", 3L, "설명", "이미지", 3L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "장소", 4L, "설명", "이미지", 4L));
+        List<Long> contentIds = List.of(1L, 2L, 3L, 4L);
+
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip1));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4));
+
 
         // when, then
         assertThat(tripRepository.findTripsByContentIds(contentIds)).hasSize(4);

--- a/backend/src/test/java/moheng/trip/presentation/TripControllerTest.java
+++ b/backend/src/test/java/moheng/trip/presentation/TripControllerTest.java
@@ -33,7 +33,7 @@ public class TripControllerTest extends ControllerTestConfig {
     @Test
     void 여행지를_생성하면_상태코드_204를_리턴한다() throws Exception {
         // given, when, then
-        mockMvc.perform(post("/trip")
+        mockMvc.perform(post("/api/trip")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(롯데월드_여행지_생성_요청()))
@@ -50,7 +50,7 @@ public class TripControllerTest extends ControllerTestConfig {
                 .willReturn(여행지_응답());
 
         // when, then
-        mockMvc.perform(get("/trip/find/interested")
+        mockMvc.perform(get("/api/trip/find/interested")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
         )
@@ -80,7 +80,7 @@ public class TripControllerTest extends ControllerTestConfig {
                 .willReturn(여행지_조회_응답());
 
         // when, then
-        mockMvc.perform(get("/trip/find/{tripId}", 1L)
+        mockMvc.perform(get("/api/trip/find/{tripId}", 1L)
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -114,7 +114,7 @@ public class TripControllerTest extends ControllerTestConfig {
         doNothing().when(tripService).createMemberTrip(anyLong(), anyLong());
 
         // when, then
-        mockMvc.perform(post("/trip/member/{tripId}", 1L)
+        mockMvc.perform(post("/api/trip/member/{tripId}", 1L)
                 .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON))

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
   main:
     allow-bean-definition-overriding: true
 


### PR DESCRIPTION
## 관련 IssueNumber

#154 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 이전까지 현재 비슷한 여행지 조회시 생활정보로 필터링하여 10개의 여행지를 찾도록 구현되는 기능이 없었습니다. 이를 위한 기능을 보충했습니다.
- 백엔드내 모든 API 의 네이밍 가장 맨 앞에 `/api` 를 추가했으니 참고 바랍니다.

