### PR TITLE
[fix] 프론트엔드 테스트 코드 커버리지 측정 비활성화

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -2,6 +2,9 @@ sonar.projectKey=moheng_frontend
 sonar.organization=kakaotech-25
 sonar.host.url=https://sonarcloud.io
 
+# 테스트 코드 커버리지 측정 비활성화 
+sonar.coverage.exclusions=**/*.js,**/*.jsx
+
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=moheng_frontend
 #sonar.projectVersion=1.0


### PR DESCRIPTION
## 관련 IssueNumber

> #196 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 프론트엔드 sonar-project.properites에 JavaScript 및 JSX 파일에 대한 커버리지 측정을 비활성화하는 코드를 추가하였습니다.

