### PR TITLE
[fix] nginx 요청 docs 백엔드 컨테이너로 라우팅

### DIFF
--- a/nginx/tools/develop.conf
+++ b/nginx/tools/develop.conf
@@ -33,7 +33,7 @@ server {
         proxy_pass http://front;
     }
 
-    location /api/ {
+    location ~* ^/(api|docs)/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/tools/production.conf
+++ b/nginx/tools/production.conf
@@ -28,7 +28,7 @@ server {
         try_files $uri $uri/ /$uri $uri.html /$uri.html $uri/index.html /404.html;
     }
 
-    location /api/ {
+    location ~* ^/(api|docs)/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 관련 IssueNumber

> #198 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- docs 디렉토리로 요청이 오면 api/로 시작하지 않아 제대로 문서가 보이지 않는 현상을 해결했습니다.
