### PR TITLE
[feat] 여행지세부페이지의 플래너에 담기 버튼을 눌렀을 때 일정리스트 모달 UI 구현

### DIFF
--- a/frontend/src/pages/TravelDetails/TravelDetails.css
+++ b/frontend/src/pages/TravelDetails/TravelDetails.css
@@ -98,35 +98,6 @@
     box-shadow: inset 0px -10px 10px -10px rgba(0, 0, 0, 0.1);
 }
 
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.modal {
-    background-color: white;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-}
-
-.modal button {
-    margin-top: 10px;
-    padding: 10px 20px;
-    background-color: #845EC2;
-    color: white;
-    border: none;
-    cursor: pointer;
-    border-radius: 5px;
-}
-
 .similar-destinations {
     margin-top: 60px;
     padding-top: 40px;
@@ -148,4 +119,85 @@
 
 .similar-place {
     margin-left: 0;
+}
+
+
+.td-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.td-modal-content {
+    background-color: #FFFFEC;
+    border-radius: 10px;
+    width: 450px;
+    text-align: left;
+}
+
+.td-modal-header {
+    background-color: #C493FF;
+    color: white;
+    padding: 1px;
+    border-radius: 10px 10px 0 0;
+    text-align: center;
+}
+
+.td-modal-body {
+    padding: 20px;
+}
+
+.td-planner-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.td-planner-list-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid #ECE6F0;
+}
+
+.td-planner-title {
+    font-size: 20px;
+    color: #333;
+}
+
+.td-planner-checkbox {
+    transform: scale(2);
+}
+
+.td-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 20px;
+}
+
+.td-modal-save-button {
+    background-color: #845EC2;
+    color: #FFFFFF;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-right: 10px;
+}
+
+.td-modal-cancel-button {
+    background-color: #ccc;
+    color: #333;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
 }

--- a/frontend/src/pages/TravelDetails/TravelDetails.css
+++ b/frontend/src/pages/TravelDetails/TravelDetails.css
@@ -179,8 +179,30 @@
 
 .td-modal-footer {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
     padding: 20px;
+}
+
+.td-add-plan-button {
+    display: flex;
+    align-items: center;
+    background-color: #845EC2;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+.td-add-plan-button:hover {
+    background-color: #724BB7;
+}
+
+.td-save-cancel-group {
+    display: flex;
+    align-items: center;
 }
 
 .td-modal-save-button {
@@ -200,4 +222,10 @@
     border: none;
     border-radius: 5px;
     cursor: pointer;
+}
+
+.add-icon {
+    width: 15px;
+    height: 15px;
+    margin-right: 8px;
 }

--- a/frontend/src/pages/TravelDetails/TravelDetails.jsx
+++ b/frontend/src/pages/TravelDetails/TravelDetails.jsx
@@ -3,14 +3,17 @@ import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import TravelData from '../../data/TravelData';
 import plannerIcon from '../../assets/plannericon.png';
+import addIcon from '../../assets/editicon.png';
 import TravelCarousel from '../../components/TravelCarousel/TravelCarousel';
 import PlannerData from '../../data/PlannerData';
+import PlannerModal from '../../components/PlannerModal/PlannerModal';
 
 const TravelDetails = () => {
   const { id } = useParams();
   const card = TravelData.find(item => item.id === parseInt(id));
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isAddPlanModalOpen, setIsAddPlanModalOpen] = useState(false);
 
   const handleAddToPlanner = () => {
     setIsModalOpen(true);
@@ -18,6 +21,14 @@ const TravelDetails = () => {
 
   const closeModal = () => {
     setIsModalOpen(false);
+  };
+
+  const handleAddPlan = () => {
+    setIsAddPlanModalOpen(true);
+  };
+
+  const closeAddPlanModal = () => {
+    setIsAddPlanModalOpen(false);
   };
 
   // 현재 여행지와 비슷한 여행지 필터링 (예: 같은 태그가 있는 여행지)
@@ -74,11 +85,30 @@ const TravelDetails = () => {
               </ul>
             </div>
             <div className="td-modal-footer">
-              <button className="td-modal-save-button">저장</button>
-              <button onClick={closeModal} className="td-modal-cancel-button">취소</button>
+              <button onClick={handleAddPlan} className="td-add-plan-button">
+                <img src={addIcon} alt="추가 아이콘" className="add-icon" />
+                일정 추가
+              </button>
+              <div className="td-save-cancel-group">
+                <button className="td-modal-save-button">저장</button>
+                <button onClick={closeModal} className="td-modal-cancel-button">취소</button>
+              </div>
             </div>
           </div>
         </div>
+      )}
+
+      {isAddPlanModalOpen && (
+        <PlannerModal
+          isOpen={isAddPlanModalOpen}
+          mode="add"
+          title="새 일정 추가"
+          onClose={closeAddPlanModal}
+          onSave={(newPlan) => {
+            PlannerData.push(newPlan);
+            closeAddPlanModal();
+          }}
+        />
       )}
 
       <section className="similar-destinations">

--- a/frontend/src/pages/TravelDetails/TravelDetails.jsx
+++ b/frontend/src/pages/TravelDetails/TravelDetails.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import TravelData from '../../data/TravelData';
 import plannerIcon from '../../assets/plannericon.png';
 import TravelCarousel from '../../components/TravelCarousel/TravelCarousel';
+import PlannerData from '../../data/PlannerData';
 
 const TravelDetails = () => {
   const { id } = useParams();
@@ -57,11 +58,25 @@ const TravelDetails = () => {
       </div>
 
       {isModalOpen && (
-        <div className="modal-overlay">
-          <div className="modal">
-            <h2>여행 일정</h2>
-            <p>----리스트 공간----</p>
-            <button onClick={closeModal}>Save</button>
+        <div className="td-modal-overlay">
+          <div className="td-modal-content">
+            <div className="td-modal-header">
+              <h2>여행 일정</h2>
+            </div>
+            <div className="td-modal-body">
+              <ul className="td-planner-list">
+                {PlannerData.map((item) => (
+                  <li key={item.id} className="td-planner-list-item">
+                    <span className="td-planner-title">{item.title}</span>
+                    <input type="checkbox" className="td-planner-checkbox" />
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="td-modal-footer">
+              <button className="td-modal-save-button">저장</button>
+              <button onClick={closeModal} className="td-modal-cancel-button">취소</button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## 관련 IssueNumber

> #195 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 여행지 세부 페이지에서 [플래너에 담기] 버튼 누르면 일정에 여행지를 담을 수 있도록 모달 띄우기
- 일정 추가 버튼을 누르면 일정 추가하기 모달을 띄워주고 일정명, 일정기간을 입력하고 저장 누르면 리스트에 추가

## 관련 스크린샷 및 참고자료 (Optional)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/effac84d-220c-42d2-83fd-2e733df2c342">
[플래너에 담기] 버튼 누르면 모달 띄워줌

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7150dd81-0f3e-444b-9d75-6c306513c3bc">
여러 일정에 담을 수 있도록 중복체크가 가능하도록 하였습니다.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3b7391f0-5cb7-4b5c-bb9d-7da82a2f0ed3">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/60a599cf-4815-4b67-86c8-73d924efecfc">
새 일정 추가 모달에서 정보를 입력하고 저장을 누르면

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fbbbd2aa-98a5-46a9-99fd-1ebdf4d2db9d">
일정리스트에 잘 들어가는 것을 확인할 수 있음
