### PR TITLE
[feat] 엑세스 토큰 만료시 리프레시 토큰을 통해 갱신하도록 하기 

### DIFF
--- a/frontend/src/pages/Login/Callback.jsx
+++ b/frontend/src/pages/Login/Callback.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import axiosInstance from './axiosInstance';
 
@@ -15,13 +15,12 @@ const Callback = () => {
           // 카카오 로그인 인증 코드를 백엔드로 전송하여 인증 처리
           const response = await axiosInstance.post("/auth/KAKAO/login", { code });
 
-          // 백엔드에서 받은 엑세스 토큰을 저장
+          // 백엔드에서 받은 엑세스 토큰과 리프레시 토큰을 저장
           const accessToken = response.data.accessToken;
           if (accessToken) {
             localStorage.setItem('accessToken', accessToken);
           }
 
-          // 백엔드에서 Set-Cookie 헤더로 리프레시 토큰을 보내는 경우, 이를 처리
           const cookies = response.headers['set-cookie'];
           if (cookies) {
             const refreshToken = cookies.find(cookie => cookie.startsWith('refresh-token'))?.split(';')[0]?.split('=')[1];

--- a/frontend/src/pages/Login/axiosInstance.jsx
+++ b/frontend/src/pages/Login/axiosInstance.jsx
@@ -1,7 +1,57 @@
 import axios from "axios";
 
+// Axios 인스턴스 생성
 const axiosInstance = axios.create({
   baseURL: "http://localhost:8080/api",
 });
+
+// 요청 인터셉터: 엑세스 토큰을 요청 헤더에 추가
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      config.headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터: 엑세스 토큰 만료 시 리프레시 토큰으로 갱신
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 엑세스 토큰 만료 시 처리
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      const refreshToken = localStorage.getItem("refreshToken");
+      if (refreshToken) {
+        try {
+          const response = await axiosInstance.post("/auth/extend/login", {
+            token: refreshToken,
+          });
+
+          const newAccessToken = response.data.accessToken;
+          if (newAccessToken) {
+            localStorage.setItem("accessToken", newAccessToken);
+            axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
+            return axiosInstance(originalRequest); // 원래의 요청을 다시 시도
+          }
+        } catch (refreshError) {
+          console.error("Failed to refresh access token:", refreshError);
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;


### PR DESCRIPTION
## 관련 IssueNumber

> #253

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 엑세스 토큰 만료 시 리프레시 토큰을 확인하여 재발급받도록 하였습니다.
