### PR TITLE
[feat] Slf4j MDC 로 멀티쓰레드 환경에서 요청별 식별 고유 ID 로그 생성 

### DIFF
--- a/backend/src/main/java/moheng/global/mdcfilter/AsyncConfig.java
+++ b/backend/src/main/java/moheng/global/mdcfilter/AsyncConfig.java
@@ -1,4 +1,4 @@
-package moheng.global.mdc;
+package moheng.global.mdcfilter;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/moheng/global/mdcfilter/MdcFilter.java
+++ b/backend/src/main/java/moheng/global/mdcfilter/MdcFilter.java
@@ -1,4 +1,4 @@
-package moheng.global.mdc;
+package moheng.global.mdcfilter;
 
 import jakarta.servlet.*;
 import org.slf4j.MDC;
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.logging.LogRecord;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/backend/src/main/java/moheng/global/mdcfilter/MdcTaskDecorator.java
+++ b/backend/src/main/java/moheng/global/mdcfilter/MdcTaskDecorator.java
@@ -1,4 +1,4 @@
-package moheng.global.mdc;
+package moheng.global.mdcfilter;
 
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -20,10 +20,17 @@
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
         </filter>
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                ${PID:-} --- [%15.15thread] %-40.40logger{36} %msg%n%n
+                [REQUEST_ID] : %X{REQUEST_ID:-NO REQUEST ID}%n
+                [REQUEST_METHOD] : %X{REQUEST_METHOD:-NO REQUEST METHOD}%n
+                [REQUEST_URI] : %X{REQUEST_URI:-NO REQUEST URI}%n
+                [REQUEST_TIME] : %d{yyyy-MM-dd HH:mm:ss.SSS}%n
+                [REQUEST_IP] : %X{REQUEST_IP:-NO REQUEST IP}%n
+            </Pattern>
             <charset>utf8</charset>
-        </encoder>
+        </layout>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./log/backup/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
@@ -40,7 +47,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %-5level [%X{REQUEST_ID:-NO REQUEST ID}] ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n%n</pattern>
             <charset>utf8</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">


### PR DESCRIPTION
## 관련 IssueNumber

> #163 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- ThreadLocal 에 고유 ID 메타정보를 추가
-  로깅 관련 의존성 추가

## 테스트 및 결과

멀티 쓰레드 환경에서 요청별 식별을 위해, 각 요청별로 고유 ID 로그를 생성했습니다. 예시는 다음과 같습니다. 

```
[REQUEST_ID] : fe06614d-7225-45a1-a91a-6513301ff176
[REQUEST_METHOD] : GET
[REQUEST_URI] : NO REQUEST URI
[REQUEST_TIME] : 2024-09-06 13:45:53.022
[REQUEST_IP] : localhost:8080
```

