### PR TITLE
[feat] 최초입력3-관심여행지 입력 페이지 연동 작업

### DIFF
--- a/frontend/src/components/TravelCard/TravelCard.jsx
+++ b/frontend/src/components/TravelCard/TravelCard.jsx
@@ -1,20 +1,25 @@
 import './TravelCard.css';
 
 const TravelCard = ({ image, tags, title, location, isSelected, onClick }) => {
+  const formatLocation = (location) => {
+    const parts = location.split(' ');
+    return parts.slice(0, 2).join(' '); // 주소에서 구까지만
+  };
+
   return (
     <div className={`travel-card ${isSelected ? 'selected' : ''}`} onClick={onClick}>
       <img src={image} alt={title} className="travel-card-image" />
       {isSelected && <div className="interested-checkmark">✔️</div>}
       <div className="travel-card-content">
         <div className="travel-card-tags">
-          {tags.map((tag, index) => (
+          {tags.slice(0, 2).map((tag, index) => ( // 태그 2개만
             <span key={index} className="travel-card-tag">
               #{tag}
             </span>
           ))}
         </div>
         <div className="travel-card-title">{title}</div>
-        <div className="travel-card-location">{location}</div>
+        <div className="travel-card-location">{formatLocation(location)}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/TravelCarousel/TravelCarousel.jsx
+++ b/frontend/src/components/TravelCarousel/TravelCarousel.jsx
@@ -28,17 +28,6 @@ const TravelCarousel = ({ cards }) => {
     navigate(`/traveldetails/${id}`);
   };
 
-  const formatLocation = (location) => {
-    const parts = location.split(' ');
-    return parts.slice(0, 2).join(' ');
-  };
-
-  const formattedCards = cards.map(card => ({
-    ...card,
-    tags: card.tags.slice(0, 2),
-    location: formatLocation(card.location)
-  }));
-
   return (
     <div className="carousel-container">
       <button className="carousel-button prev" onClick={handlePrevClick}>
@@ -49,7 +38,7 @@ const TravelCarousel = ({ cards }) => {
           className="carousel-track"
           style={{ transform: `translateX(-${currentIndex * (100 / cardsToShow)}%)` }}
         >
-          {formattedCards.map((card, index) => (
+          {cards.map((card, index) => (
             <div key={index} className="carousel-card">
               <TravelCard
                 {...card}

--- a/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
+++ b/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
@@ -10,7 +10,7 @@ import axiosInstance from "../Login/axiosInstance";
 const InterestedPlace = () => {
   const navigate = useNavigate();
   const [locations, setLocations] = useState([]);
-  const [selectedCards, setSelectedCards] = useState([]); // 선택된 카드를 저장하는 상태
+  const [selectedCards, setSelectedCards] = useState([]); // 선택된 여행지의 contentId 저장
 
   // API 호출로 여행지 데이터 불러오기
   useEffect(() => {
@@ -37,6 +37,7 @@ const InterestedPlace = () => {
     fetchData();
   }, []);
 
+  // 여행지 선택 처리
   const handleCardClick = (id) => {
     setSelectedCards((prevSelected) => {
       if (prevSelected.includes(id)) {
@@ -47,7 +48,8 @@ const InterestedPlace = () => {
     });
   };
 
-  const handleSubmit = () => {
+  // 완료 버튼 클릭 시 선택된 여행지 contentId를 POST 요청으로 전송
+  const handleSubmit = async () => {
     const selectedCount = selectedCards.length;
     if (selectedCount < 5 || selectedCount > 11) {
       alert(
@@ -55,8 +57,24 @@ const InterestedPlace = () => {
           ? `관심 여행지를 5개 이상 선택해주세요! (${selectedCount}/5)`
           : `관심 여행지는 최대 10개까지만 선택 가능합니다! (${selectedCount}/10)`
       );
-    } else {
-      navigate("/"); // 선택된 카드가 5개 이상 10개 이하일 때 지정된 URL로 이동
+      return;
+    }
+
+    try {
+      const payload = {
+        contentIds: selectedCards, // 선택된 여행지의 contentId 리스트 전송
+      };
+
+      const response = await axiosInstance.post("/member/signup/trip", payload);
+
+      if (response.status === 204) {
+        console.log("POST 요청 성공");
+        navigate(`/`); // 성공 시 메인 페이지로 이동
+      } else {
+        console.error("응답 실패:", response);
+      }
+    } catch (error) {
+      console.error("POST 요청 실패:", error);
     }
   };
 

--- a/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
+++ b/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
@@ -32,12 +32,17 @@ const InterestedPlace = () => {
 
     const handleSubmit = () => {
         const selectedCount = selectedCards.length;
-        if (selectedCount < 5) {
-            alert(`관심여행지를 5개 이상 선택해주세요! (${selectedCount}/5)`);
+        if (selectedCount < 5 || selectedCount > 11) {
+            alert(
+              selectedCount < 5
+                ? `관심여행지를 5개 이상 선택해주세요! (${selectedCount}/5)`
+                : `관심여행지는 최대 10개까지만 선택 가능합니다! (${selectedCount}/10)`
+            );
         } else {
-            navigate(`/`); // 선택된 카드가 5개 이상일 때 지정된 URL로 이동
+            navigate(`/`); // 선택된 카드가 5개 이상 10개 이하일 때 지정된 URL로 이동
         }
     };
+    
 
     return (
         <section className="interested-page">

--- a/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
+++ b/frontend/src/pages/InterestedPlace/InterestedPlace.jsx
@@ -5,69 +5,85 @@ import TravelCard from "../../components/TravelCard/TravelCard";
 import Button from "../../components/Button/Button";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import TravelData from '../../data/TravelData';
+import axiosInstance from "../Login/axiosInstance";
 
 const InterestedPlace = () => {
-    const navigate = useNavigate();
-    const [locations, setLocations] = useState([]);
-    const [selectedCards, setSelectedCards] = useState([]); // 선택된 카드를 저장하는 상태
+  const navigate = useNavigate();
+  const [locations, setLocations] = useState([]);
+  const [selectedCards, setSelectedCards] = useState([]); // 선택된 카드를 저장하는 상태
 
-    useEffect(() => {
-        const fetchData = async () => {
-            setLocations(TravelData);
-        };
-
-        fetchData();
-    }, []);
-
-    const handleCardClick = (id) => {
-        setSelectedCards(prevSelected => {
-            if (prevSelected.includes(id)) {
-                return prevSelected.filter(cardId => cardId !== id); // 이미 선택된 카드 클릭 시 선택 해제
-            } else {
-                return [...prevSelected, id]; // 선택되지 않은 카드 클릭 시 선택 추가
-            }
-        });
+  // API 호출로 여행지 데이터 불러오기
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axiosInstance.get("/trip/find/interested");
+        const tripData = response.data.findTripResponses;
+        // 데이터 매핑하여 state에 저장
+        setLocations(
+          tripData.map((location) => ({
+            id: location.contentId,
+            image: location.tripImageUrl,
+            tags: location.keywords,
+            title: location.name,
+            location: location.placeName,
+            description: location.description,
+          }))
+        );
+      } catch (error) {
+        console.error("데이터 가져오기 실패:", error);
+      }
     };
 
-    const handleSubmit = () => {
-        const selectedCount = selectedCards.length;
-        if (selectedCount < 5 || selectedCount > 11) {
-            alert(
-              selectedCount < 5
-                ? `관심여행지를 5개 이상 선택해주세요! (${selectedCount}/5)`
-                : `관심여행지는 최대 10개까지만 선택 가능합니다! (${selectedCount}/10)`
-            );
-        } else {
-            navigate(`/`); // 선택된 카드가 5개 이상 10개 이하일 때 지정된 URL로 이동
-        }
-    };
-    
+    fetchData();
+  }, []);
 
-    return (
-        <section className="interested-page">
-            <ProfileInfo text={"AI 맞춤 추천을 위해 관심 여행지를 5개 이상 선택해주세요."} src={progressbar3} />
+  const handleCardClick = (id) => {
+    setSelectedCards((prevSelected) => {
+      if (prevSelected.includes(id)) {
+        return prevSelected.filter((cardId) => cardId !== id); // 이미 선택된 카드 클릭 시 선택 해제
+      } else {
+        return [...prevSelected, id]; // 선택되지 않은 카드 클릭 시 선택 추가
+      }
+    });
+  };
 
-            <section className="interested-body">
-                <section className="travel-grid">
-                    {locations.map(location => (
-                        <TravelCard
-                            key={location.id}
-                            image={location.image}
-                            tags={location.tags}
-                            title={location.title}
-                            location={location.location}
-                            isSelected={selectedCards.includes(location.id)} // 선택 상태 전달
-                            onClick={() => handleCardClick(location.id)} // 클릭 핸들러 전달
-                        />
-                    ))}
-                </section>
-                <section className="subbtn">
-                    <Button text={"완료"} onClick={handleSubmit} />
-                </section>
-            </section>
+  const handleSubmit = () => {
+    const selectedCount = selectedCards.length;
+    if (selectedCount < 5 || selectedCount > 11) {
+      alert(
+        selectedCount < 5
+          ? `관심 여행지를 5개 이상 선택해주세요! (${selectedCount}/5)`
+          : `관심 여행지는 최대 10개까지만 선택 가능합니다! (${selectedCount}/10)`
+      );
+    } else {
+      navigate("/"); // 선택된 카드가 5개 이상 10개 이하일 때 지정된 URL로 이동
+    }
+  };
+
+  return (
+    <section className="interested-page">
+      <ProfileInfo text={"AI 맞춤 추천을 위해 관심 여행지를 5개 이상 선택해주세요."} src={progressbar3} />
+
+      <section className="interested-body">
+        <section className="travel-grid">
+          {locations.map((location) => (
+            <TravelCard
+              key={location.id}
+              image={location.image}
+              tags={location.tags}
+              title={location.title}
+              location={location.location}
+              isSelected={selectedCards.includes(location.id)} // 선택 상태 전달
+              onClick={() => handleCardClick(location.id)} // 클릭 핸들러 전달
+            />
+          ))}
         </section>
-    );
+        <section className="subbtn">
+          <Button text={"완료"} onClick={handleSubmit} />
+        </section>
+      </section>
+    </section>
+  );
 };
 
 export default InterestedPlace;


### PR DESCRIPTION
## 관련 IssueNumber

> #231

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 최초입력3 페이지에서 관심여행지를 클릭하고 데이터를 전달하는 과정의 연동작업을 진행했습니다.
- 여행지캐러셀에서 태그 두개 주소는 구까지만 표시되도록 구현해둔 부분을 여행지카드에서 처리하도록 하였습니다. 태그가 하나인 곳은 하나만 나오도록 되어있습니다.
- GET 요청을 통해 여행지 데이터를 불러와서 여행지 카드 형태로 보여줍니다.
![image](https://github.com/user-attachments/assets/7408d6a3-0d03-4338-af42-68a829718a36)
- 여행지는 5개 이상 10개 이하로 선택하도록 했고, 이 부분은 이미 프론트에서 구현이 된 부분이 있어서 프론트에서 확인하도록 했습니다.
- 완료버튼을 통해 POST 요청을 보내고 요청이 성공하면 메인페이지로 넘어가도록 했습니다.
- 완료버튼을 통해 최초가입과정이 모두 성공적으로 완료되면 정식회원이 되어서 최초입력에서는 403 오류가 나오는 것을 확인했습니다.
