### PR TITLE
[test] 유저 시나리오를 문서화화고, 여러 API 를 호출하는 E2E 인수 테스트 진행 

### DIFF
--- a/backend/src/main/java/moheng/member/domain/Member.java
+++ b/backend/src/main/java/moheng/member/domain/Member.java
@@ -155,4 +155,8 @@ public class Member extends BaseEntity {
     public Authority getAuthority() {
         return authority;
     }
+
+    public SocialType getSocialType() {
+        return socialType;
+    }
 }

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -698,7 +698,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: refresh-token=refresh-token; Path=/; Max-Age=604800; Expires=Sat, 14 Sep 2024 08:17:41 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: refresh-token=refresh-token; Path=/; Max-Age=604800; Expires=Sun, 15 Sep 2024 07:56:40 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 36
 
@@ -4821,9 +4821,10 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 742
+Content-Length: 774
 
 {
+  "keywordName" : "키워드1",
   "findTripResponses" : [ {
     "name" : "롯데월드1",
     "placeName" : "서울특별시 송파구1",
@@ -4837,14 +4838,14 @@ Content-Length: 742
     "contentId" : 1182080,
     "tripImageUrl" : "https://lotte-world.ong",
     "description" : "롯데월드 설명2",
-    "keywords" : [ "키워드2" ]
+    "keywords" : [ "키워드1" ]
   }, {
     "name" : "롯데월드3",
     "placeName" : "서울특별시 송파구3",
     "contentId" : 9820280,
     "tripImageUrl" : "https://lotte-world.ong",
     "description" : "롯데월드 설명3",
-    "keywords" : [ "키워드3" ]
+    "keywords" : [ "키워드1" ]
   } ]
 }</code></pre>
 </div>
@@ -4865,6 +4866,11 @@ Content-Length: 742
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keywordName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">랜덤으로 선택된 현재 키워드 이름</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>findTripResponses</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>

--- a/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
@@ -153,9 +153,9 @@ public class MemberAcceptanceTest extends AcceptanceTestConfig {
         });
     }
 
-    @DisplayName("소셜 로그인 후 최초 회원가입을 마친 멤버의 프로필 정보와 생활정보 정보는 비어있을 수 없다.")
+    @DisplayName("소셜 로그인 후 최초 회원가입을 마친 멤버의 프로필 정보와 생활정보는 비어있을 수 없다.")
     @Test
-    void 소셜_로그인_후_최초_회원가입을_마친_멤버의_생활정보는_비어있을_수_없다() {
+    void 소셜_로그인_후_최초_회원가입을_마친_멤버의_프로필_정보와_생활정보는_비어있을_수_없다() {
         // given
         ExtractableResponse<Response> response = 자체_토큰을_생성한다("KAKAO", "authorization-code");
         AccessTokenResponse accessTokenResponse = response.as(AccessTokenResponse.class);

--- a/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
@@ -1,12 +1,11 @@
 package moheng.acceptance;
 
+import static moheng.acceptance.fixture.MemberAcceptanceFixture.*;
 import static moheng.acceptance.fixture.TripAcceptenceFixture.*;
 import static moheng.acceptance.fixture.LiveInfoAcceptenceFixture.*;
 import static moheng.acceptance.fixture.AuthAcceptanceFixture.*;
 import static moheng.acceptance.fixture.HttpStatusAcceptenceFixture.상태코드_200이_반환된다;
-import static moheng.acceptance.fixture.MemberAcceptanceFixture.*;
 import static moheng.acceptance.fixture.HttpStatusAcceptenceFixture.*;
-import static moheng.acceptance.fixture.MemberAcceptanceFixture.프로필_정보로_회원가입을_한다;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -128,6 +127,28 @@ public class MemberAcceptanceTest extends AcceptanceTestConfig {
         // then
         assertAll(() -> {
             상태코드_204이_반환된다(resultResponse);
+        });
+    }
+
+    @DisplayName("소셜 로그인 후 최초 회원가입을 마친 멤버의 모든 프로필 정보는 null 일 수 없다.")
+    @Test
+    void 소셜_로그인_후_최초_회원가입을_마친_멤버의_모든_프로필_정보는_null_일_수_없다() {
+        // given, when
+        ExtractableResponse<Response> response = 자체_토큰을_생성한다("KAKAO", "authorization-code");
+        AccessTokenResponse accessTokenResponse = response.as(AccessTokenResponse.class);
+        프로필_정보로_회원가입을_한다(accessTokenResponse.getAccessToken());
+
+        // then
+        ExtractableResponse<Response> memberResponse = 회원_본인의_정보를_조회한다(accessTokenResponse.getAccessToken());
+        MemberResponse resultResponse = memberResponse.as(MemberResponse.class);
+
+        assertAll(() -> {
+            assertThat(resultResponse.getId()).isNotNull();
+            assertThat(resultResponse.getBirthday()).isNotNull();
+            assertThat(resultResponse.getNickname()).isNotNull();
+            assertThat(resultResponse.getProfileImageUrl()).isNotNull();
+            assertThat(resultResponse.getGenderType()).isNotNull();
+            assertThat(memberResponse.statusCode()).isEqualTo(200);
         });
     }
 }

--- a/backend/src/test/java/moheng/auth/domain/JwtTokenManagerTest.java
+++ b/backend/src/test/java/moheng/auth/domain/JwtTokenManagerTest.java
@@ -2,12 +2,7 @@ package moheng.auth.domain;
 
 import static moheng.fixture.JwtTokenFixtures.*;
 import static moheng.fixture.JwtTokenFixtures.EXPIRED_TOKEN_TIME;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_1;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_2;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_3;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_4;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_5;
-import static moheng.fixture.MemberFixtures.MEMBER_ID_6;
+import static moheng.fixture.MemberFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,7 +22,7 @@ public class JwtTokenManagerTest {
 
     @DisplayName("memberId로 엑세스 토큰과 리프레시 토큰을 생성한다.")
     @ParameterizedTest
-    @ValueSource(longs = {1L, 2L, 3L})
+    @ValueSource(longs = {MEMBER_ID_1, MEMBER_ID_2, MEMBER_ID_3})
     void memberId_로_엑세스_토큰과_리프레시_토큰을_생성한다(long memberId) {
         // given, when
         MemberToken memberToken = jwtTokenManager.createMemberToken(memberId);
@@ -38,7 +33,6 @@ public class JwtTokenManagerTest {
                 () -> assertThat(memberToken.getRefreshToken()).isNotEmpty()
         );
     }
-
 
     @DisplayName("리프레시 토큰으로 새로운 엑세스 토큰을 발급받는다.")
     @Test
@@ -124,8 +118,8 @@ public class JwtTokenManagerTest {
     @Test
     void 전달받은_리프레시_토큰과_DB_에_저장된_회원의_리프레시_토큰이_다르면_예외가_발생한다() {
         // given
-        jwtTokenManager.createMemberToken(MEMBER_ID_1);
-        String otherRefreshToken = jwtTokenProvider.createRefreshToken(MEMBER_ID_2);
+        jwtTokenManager.createMemberToken(MEMBER_ID_5);
+        String otherRefreshToken = jwtTokenProvider.createRefreshToken(MEMBER_ID_8);
 
         // when, then
         assertThatThrownBy(() -> jwtTokenManager.generateRenewalAccessToken(otherRefreshToken))

--- a/backend/src/test/java/moheng/auth/domain/JwtTokenManagerTest.java
+++ b/backend/src/test/java/moheng/auth/domain/JwtTokenManagerTest.java
@@ -17,17 +17,20 @@ import moheng.auth.exception.InvalidTokenException;
 import moheng.auth.exception.NoExistMemberTokenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class JwtTokenManagerTest {
     private final InMemoryRefreshTokenRepository refreshTokenRepository = new InMemoryRefreshTokenRepository();
     private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME, REFRESH_TOKEN_EXPIRE_TIME);
     private final JwtTokenManager jwtTokenManager = new JwtTokenManager(refreshTokenRepository, jwtTokenProvider);
 
-    @DisplayName("memberId 로 엑세스 토큰과 리프레시 토큰을 생성한다.")
-    @Test
-    void memberId_로_엑세스_토큰과_리프레시_토큰을_생성한다() {
+    @DisplayName("memberId로 엑세스 토큰과 리프레시 토큰을 생성한다.")
+    @ParameterizedTest
+    @ValueSource(longs = {1L, 2L, 3L})
+    void memberId_로_엑세스_토큰과_리프레시_토큰을_생성한다(long memberId) {
         // given, when
-        MemberToken memberToken = jwtTokenManager.createMemberToken(MEMBER_ID_1);
+        MemberToken memberToken = jwtTokenManager.createMemberToken(memberId);
 
         // then
         assertAll(
@@ -35,6 +38,7 @@ public class JwtTokenManagerTest {
                 () -> assertThat(memberToken.getRefreshToken()).isNotEmpty()
         );
     }
+
 
     @DisplayName("리프레시 토큰으로 새로운 엑세스 토큰을 발급받는다.")
     @Test

--- a/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
+++ b/backend/src/test/java/moheng/liveinformation/application/MemberLiveInformationServiceTest.java
@@ -2,7 +2,6 @@ package moheng.liveinformation.application;
 
 import static moheng.fixture.MemberFixtures.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
+++ b/backend/src/test/java/moheng/liveinformation/domain/MemberLiveInformationRepositoryTest.java
@@ -1,8 +1,6 @@
 package moheng.liveinformation.domain;
 
 import static moheng.fixture.MemberFixtures.*;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import moheng.config.slice.RepositoryTestConfig;

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -291,15 +291,15 @@ public class MemberServiceTest extends ServiceTestConfig {
     }
 
     @DisplayName("회원이 선택한 관심 여행지 우선순위를 1위부터 시작하여 순차대로 저장한다.")
-    @Test
-    void 회원이_선택한_관심_여행지_우선순위를_1위부터_시작하여_순차대로_저장한다() {
+    @ParameterizedTest
+    @MethodSource("관심_여행지_랭크_값을_찾는다")
+    void 회원이_선택한_관심_여행지_우선순위를_1위부터_시작하여_순차대로_저장한다(long expectedRank) {
         // given
         memberService.save(하온_기존());
         long memberId = memberService.findByEmail(하온_이메일).getId();
 
-        for(long contentId=1; contentId<=5; contentId++) {
-            tripService.save(new Trip("롯데월드", "서울특별시 송파구", contentId,
-                    "설명", "https://image.com"));
+        for (long contentId = 1; contentId <= 5; contentId++) {
+            tripService.save(new Trip("롯데월드", "서울특별시 송파구", contentId, "설명", "https://image.com"));
         }
         SignUpInterestTripsRequest request = new SignUpInterestTripsRequest(List.of(1L, 2L, 3L, 4L, 5L));
 
@@ -308,10 +308,18 @@ public class MemberServiceTest extends ServiceTestConfig {
 
         // then
         assertAll(() -> {
-            for(long rank=1; rank<=5; rank++) {
-                assertEquals(recommendTripRepository.findById(rank).get().getRanking(), rank);
-            }
+            assertEquals(recommendTripRepository.findById(expectedRank).get().getRanking(), expectedRank);
         });
+    }
+
+    static Stream<Arguments> 관심_여행지_랭크_값을_찾는다() {
+        return Stream.of(
+                Arguments.of(1L),
+                Arguments.of(2L),
+                Arguments.of(3L),
+                Arguments.of(4L),
+                Arguments.of(5L)
+        );
     }
 
     @DisplayName("존재하지 않는 회원의 관심 여행지를 저장하면 예외가 발생한다.")

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -402,7 +402,7 @@ public class MemberServiceTest extends ServiceTestConfig {
 
     @DisplayName("소셜 로그인 후 최초 회원가입을 마친 멤버의 각 프로필 정보는 null 일 수 없다.")
     @ParameterizedTest
-    @MethodSource("provideMemberFieldAndValue")
+    @MethodSource("멤버의_프로필_정보를_찾는다")
     void 소셜_로그인_후_최초_회원가입을_마친_멤버의_프로필_정보가_null_아님을_확인(Function<Member, Object> fieldExtractor) {
         // given
         authService.generateTokenWithCode("code", "KAKAO");
@@ -417,7 +417,7 @@ public class MemberServiceTest extends ServiceTestConfig {
         assertThat(fieldValue).isNotNull();
     }
 
-    static Stream<Arguments> provideMemberFieldAndValue() {
+    static Stream<Arguments> 멤버의_프로필_정보를_찾는다() {
         return Stream.of(
                 Arguments.of((Function<Member, Object>) Member::getId),
                 Arguments.of((Function<Member, Object>) Member::getNickName),
@@ -430,7 +430,7 @@ public class MemberServiceTest extends ServiceTestConfig {
 
     @DisplayName("소셜 로그인 후 최초 회원가입을 마친 멤버의 프로필 정보와 생활정보와 관심 여행지 정보는 비어있을 수 없다.")
     @ParameterizedTest
-    @MethodSource("provideMemberProfileFieldsAndValues")
+    @MethodSource("멤버의_프로필_정보와_생활정보_및_관심_여행지_기댓값을_찾는다")
     void 소셜_로그인_후_최초_회원가입을_마친_멤버의_프로필_정보와_생활정보와_관심_여행지_정보는_비어있을_수_없다(Function<Member, Object> fieldExtractor, int expectedLiveInfoSize, int expectedTripSize) {
         // given
         authService.generateTokenWithCode("code", "KAKAO");
@@ -465,7 +465,7 @@ public class MemberServiceTest extends ServiceTestConfig {
         });
     }
 
-    static Stream<Arguments> provideMemberProfileFieldsAndValues() {
+    static Stream<Arguments> 멤버의_프로필_정보와_생활정보_및_관심_여행지_기댓값을_찾는다() {
         return Stream.of(
                 Arguments.of((Function<Member, Object>) Member::getId, 2, 5),
                 Arguments.of((Function<Member, Object>) Member::getNickName, 2, 5),
@@ -478,7 +478,7 @@ public class MemberServiceTest extends ServiceTestConfig {
 
     @DisplayName("멤버의 프로필을 수정했을 때 멤버의 모든 프로필 정보는 null 일 수 없으며 생활정보는 변하지 않는다.")
     @ParameterizedTest
-    @MethodSource("provideMemberProfileFieldsForUpdate")
+    @MethodSource("멤버의_프로필_정보와_생활정보_기댓값을_찾는다")
     void 멤버의_프로필을_수정했을_때_멤버의_모든_프로필_정보는_null_일_수_없으며_멤버의_생활정보는_변하지_않는다(Function<Member, Object> fieldExtractor, int expectedLiveInfoSize) {
         // given
         authService.generateTokenWithCode("code", "KAKAO");
@@ -507,7 +507,7 @@ public class MemberServiceTest extends ServiceTestConfig {
         });
     }
 
-    static Stream<Arguments> provideMemberProfileFieldsForUpdate() {
+    static Stream<Arguments> 멤버의_프로필_정보와_생활정보_기댓값을_찾는다() {
         return Stream.of(
                 Arguments.of((Function<Member, Object>) Member::getId, 2),
                 Arguments.of((Function<Member, Object>) Member::getNickName, 2),


### PR DESCRIPTION
## 관련 IssueNumber

> #293 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 단일 API 를 호출했을떄는 문제 없이 동작하나, 간혹 여러 API 를 혼합하여 호출했을 시 비즈니스 로직을 만족하지 못하는 경우가 발생합니다. 이를 위한 인수 테스트를 진행하여, 더 믿음직한 프로뎍선 코드로 개선했습니다.