### PR TITLE
[refactor] 키워드, 생활정보, 멤버 도메인에 발생하는 N+1 문제 해결 및 쿼리 성능개선 

### DIFF
--- a/backend/src/main/java/moheng/applicationrunner/dev/KeywordDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/KeywordDevApplicationRunner.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Order(4)
+@Order(3)
 @Component
 public class KeywordDevApplicationRunner implements ApplicationRunner {
     private final KeywordRepository keywordRepository;

--- a/backend/src/main/java/moheng/applicationrunner/dev/LiveInformationDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/LiveInformationDevApplicationRunner.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Order(3)
+@Order(2)
 @Component
 public class LiveInformationDevApplicationRunner implements ApplicationRunner {
     private final TripRepository tripRepository;

--- a/backend/src/main/java/moheng/applicationrunner/dev/MemberLiveInformationDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/MemberLiveInformationDevApplicationRunner.java
@@ -2,29 +2,52 @@ package moheng.applicationrunner.dev;
 
 import moheng.liveinformation.domain.repository.LiveInformationRepository;
 import moheng.liveinformation.domain.repository.MemberLiveInformationRepository;
+import moheng.member.domain.GenderType;
+import moheng.member.domain.Member;
+import moheng.member.domain.SocialType;
 import moheng.member.domain.repository.MemberRepository;
+import moheng.recommendtrip.domain.RecommendTrip;
+import moheng.recommendtrip.domain.repository.RecommendTripRepository;
+import moheng.trip.domain.repository.TripRepository;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-@Order(1)
+import java.time.LocalDate;
+
+@Order(4)
 @Component
 public class MemberLiveInformationDevApplicationRunner implements ApplicationRunner {
     private final MemberLiveInformationRepository memberLiveInformationRepository;
     private final MemberRepository memberRepository;
-    private final LiveInformationRepository liveInformationRepository;
+    private final RecommendTripRepository recommendTripRepository;
+    private final TripRepository tripRepository;
 
     public MemberLiveInformationDevApplicationRunner(final MemberLiveInformationRepository memberLiveInformationRepository,
                                                      final MemberRepository memberRepository,
-                                                     final LiveInformationRepository liveInformationRepository) {
+                                                     final RecommendTripRepository recommendTripRepository,
+                                                     final TripRepository tripRepository) {
         this.memberLiveInformationRepository = memberLiveInformationRepository;
         this.memberRepository = memberRepository;
-        this.liveInformationRepository = liveInformationRepository;
+        this.recommendTripRepository = recommendTripRepository;
+        this.tripRepository = tripRepository;
     }
 
     @Override
     public void run(ApplicationArguments args) {
+        Member member = memberRepository.save(new Member(1L, "msung6924@kakao.com", "devhaon", "https://default.png", SocialType.KAKAO,
+                LocalDate.of(2000, 1, 1), GenderType.MEN));
 
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(1L).get(), member, 1L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(2L).get(), member, 2L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(3L).get(), member, 3L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(4L).get(), member, 4L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(5L).get(), member, 5L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(6L).get(), member, 6L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(7L).get(), member, 7L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(8L).get(), member, 8L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(9L).get(), member, 9L));
+        recommendTripRepository.save(new RecommendTrip(tripRepository.findById(10L).get(), member, 10L));
     }
 }

--- a/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-@Order(2)
+@Order(1)
 @Component
 public class TripDevApplicationRunner implements ApplicationRunner {
     private final JdbcTemplate jdbcTemplate;

--- a/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
@@ -44,7 +44,6 @@ public class TripDevApplicationRunner implements ApplicationRunner {
             String sql = "INSERT INTO trip (name, place_name, content_id, description, trip_image_url, visited_count, coordinate_x, coordinate_y, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             List<Object[]> batchArgs = new ArrayList<>();
-            long cnt = 1;
             for (final TripRunner tripRunner : tripRunners) {
                 batchArgs.add(new Object[]{
                         tripRunner.getTitle(),
@@ -52,7 +51,7 @@ public class TripDevApplicationRunner implements ApplicationRunner {
                         tripRunner.getContentid(),
                         tripRunner.getOverview(),
                         tripRunner.getFirstimage(),
-                        cnt++,
+                        0L,
                         tripRunner.getMapx(),
                         tripRunner.getMapy(),
                         LocalDate.now(),

--- a/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
+++ b/backend/src/main/java/moheng/applicationrunner/dev/TripDevApplicationRunner.java
@@ -44,6 +44,7 @@ public class TripDevApplicationRunner implements ApplicationRunner {
             String sql = "INSERT INTO trip (name, place_name, content_id, description, trip_image_url, visited_count, coordinate_x, coordinate_y, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             List<Object[]> batchArgs = new ArrayList<>();
+            long cnt = 1;
             for (final TripRunner tripRunner : tripRunners) {
                 batchArgs.add(new Object[]{
                         tripRunner.getTitle(),
@@ -51,7 +52,7 @@ public class TripDevApplicationRunner implements ApplicationRunner {
                         tripRunner.getContentid(),
                         tripRunner.getOverview(),
                         tripRunner.getFirstimage(),
-                        0L,
+                        cnt++,
                         tripRunner.getMapx(),
                         tripRunner.getMapy(),
                         LocalDate.now(),

--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -90,9 +90,7 @@ public class KeywordService {
     }
 
     private List<TripKeyword> extractAllTripKeywordsByTopTrips(final List<Trip> topTrips) {
-        return topTrips.stream()
-                .flatMap(topTrip -> tripKeywordRepository.findByTrip(topTrip).stream())
-                .collect(Collectors.toList());
+        return tripKeywordRepository.findByTripIn(topTrips);
     }
 
     @Transactional

--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -12,6 +12,7 @@ import moheng.keyword.dto.KeywordCreateRequest;
 import moheng.keyword.dto.TripsByKeyWordsRequest;
 import moheng.keyword.exception.NoExistKeywordException;
 import moheng.trip.domain.Trip;
+import moheng.trip.dto.FindTripResponse;
 import moheng.trip.dto.FindTripsResponse;
 import moheng.trip.dto.TripKeywordCreateRequest;
 import moheng.trip.exception.NoExistTripException;
@@ -19,7 +20,10 @@ import moheng.trip.domain.repository.TripRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
@@ -90,7 +94,16 @@ public class KeywordService {
     }
 
     private List<TripKeyword> extractAllTripKeywordsByTopTrips(final List<Trip> topTrips) {
-        return tripKeywordRepository.findByTripIn(topTrips);
+        final Map<Trip, List<TripKeyword>> tripWithKeywords = findTripsWithTripKeywords(topTrips);
+        return topTrips.stream()
+                .flatMap(trip -> tripWithKeywords.getOrDefault(trip, Collections.emptyList()).stream())
+                .collect(Collectors.toList());
+    }
+
+    private Map<Trip, List<TripKeyword>> findTripsWithTripKeywords(final List<Trip> topTrips) {
+        return tripKeywordRepository.findByTripIn(topTrips)
+                .stream()
+                .collect(Collectors.groupingBy(TripKeyword::getTrip));
     }
 
     @Transactional

--- a/backend/src/main/java/moheng/keyword/domain/repository/TripKeywordRepository.java
+++ b/backend/src/main/java/moheng/keyword/domain/repository/TripKeywordRepository.java
@@ -14,7 +14,11 @@ public interface TripKeywordRepository extends JpaRepository<TripKeyword, Long> 
     @Query("SELECT tk FROM TripKeyword tk WHERE tk.keyword.id IN :keywordIds")
     List<TripKeyword> findTripKeywordsByKeywordIds(@Param("keywordIds") final List<Long> keywordIds);
 
+    @EntityGraph(attributePaths = {"trip"})
     List<TripKeyword> findTop30ByKeywordId(@Param("keywordId") final Long keywordId);
+
+    @EntityGraph(attributePaths = {"trip"})
+    List<TripKeyword> findByTripIn(@Param("trips") final List<Trip> trips);
 
     @Query("SELECT tk FROM TripKeyword tk WHERE tk.trip IN :trips")
     List<TripKeyword> findByTrips(@Param("trips") final List<Trip> trips);

--- a/backend/src/main/java/moheng/keyword/domain/repository/TripKeywordRepository.java
+++ b/backend/src/main/java/moheng/keyword/domain/repository/TripKeywordRepository.java
@@ -17,7 +17,7 @@ public interface TripKeywordRepository extends JpaRepository<TripKeyword, Long> 
     @EntityGraph(attributePaths = {"trip"})
     List<TripKeyword> findTop30ByKeywordId(@Param("keywordId") final Long keywordId);
 
-    @EntityGraph(attributePaths = {"trip"})
+    @EntityGraph(attributePaths = {"trip", "keyword"})
     List<TripKeyword> findByTripIn(@Param("trips") final List<Trip> trips);
 
     @Query("SELECT tk FROM TripKeyword tk WHERE tk.trip IN :trips")

--- a/backend/src/main/java/moheng/keyword/domain/statistics/TripsByVisitedCountFinder.java
+++ b/backend/src/main/java/moheng/keyword/domain/statistics/TripsByVisitedCountFinder.java
@@ -14,7 +14,7 @@ public class TripsByVisitedCountFinder implements TripsByStatisticsFinder {
 
     public List<Trip> findTripsWithVisitedCount(final List<TripKeyword> tripKeywords) {
         final Map<Trip, Long> tripClickCounts = new HashMap<>();
-        for (TripKeyword tripKeyword : tripKeywords) {
+        for (final TripKeyword tripKeyword : tripKeywords) {
             final Trip trip = tripKeyword.getTrip();
             tripClickCounts.put(tripKeyword.getTrip(), trip.getVisitedCount());
         }

--- a/backend/src/test/java/moheng/keyword/application/KeywordServiceTest.java
+++ b/backend/src/test/java/moheng/keyword/application/KeywordServiceTest.java
@@ -21,6 +21,7 @@ import moheng.recommendtrip.domain.repository.RecommendTripRepository;
 import moheng.trip.application.TripService;
 import moheng.trip.domain.Trip;
 import moheng.trip.domain.repository.TripRepository;
+import moheng.trip.dto.FindTripResponse;
 import moheng.trip.dto.FindTripsResponse;
 import moheng.trip.dto.TripKeywordCreateRequest;
 import moheng.trip.exception.NoExistTripException;
@@ -231,8 +232,12 @@ public class KeywordServiceTest extends ServiceTestConfig {
         // given
         keywordRepository.save(new Keyword("키워드1"));
 
-        for (final Trip trip : trips) {
-            tripRepository.save(trip);
+        tripRepository.save(new Trip("여행지1", "장소명1", 1L, "설명1", "이미지 경로1", 100L));
+        tripRepository.save(new Trip("여행지2", "장소명1", 1L, "설명1", "이미지 경로1", 300L));
+        tripRepository.save(new Trip("여행지3", "장소명1", 1L, "설명1", "이미지 경로1", 200L));
+
+        for (final Trip inputTrip : trips) {
+            Trip trip = tripRepository.save(inputTrip);
             tripKeywordRepository.save(new TripKeyword(trip, keywordRepository.findById(1L).get()));
         }
 


### PR DESCRIPTION
## 관련 IssueNumber

> #221 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 이전에 N+1 과 같은 비정상적으로 쿼리가 많이 나가는 현상을 발견하고 해겷하기 위해 개발해놓은 쿼리 카운터를 활용했습니다.
-  키워드, 생활정보, 멤버 도메인에 비정상적으로 쿼리가 많이 나가는 로직들을 모두 `EntityGraph` 를 통해 N+1 문제를 해결했습니다.
