### PR TITLE
[feat] 마이페이지 연동작업

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -38,7 +38,7 @@ services:
     networks:
       - moheng-network
     ports: # CORS 3000 allowed
-      - 3000:5173 # host:container
+      - 3000:3000 # host:container
     restart: always
     environment:
       - NODE_ENV=development

--- a/compose.frontend.yaml
+++ b/compose.frontend.yaml
@@ -10,7 +10,7 @@ services:
     networks:
       - moheng_network
     ports:
-      - 3000:5173
+      - 3000:3000
     restart: always
     environment:
       - NODE_ENV=development

--- a/frontend/src/components/LivingBtn/LivingBtn.jsx
+++ b/frontend/src/components/LivingBtn/LivingBtn.jsx
@@ -16,7 +16,7 @@ const LivingBtn = ({ onChangeSelection, selectedOptions = ["해당없음"] }) =>
     { img: livingimg2, text: "시각장애" },
     { img: livingimg3, text: "청각장애" },
     { img: livingimg4, text: "영유아가족" },
-    { img: livingimg5, text: "고령인" },
+    { img: livingimg5, text: "고령자" },
     { img: livingimg6, text: "해당없음" },
   ];
 

--- a/frontend/src/components/LivingBtn/LivingBtn.jsx
+++ b/frontend/src/components/LivingBtn/LivingBtn.jsx
@@ -8,8 +8,10 @@ import livingimg5 from "../../assets/senior.png";
 import livingimg6 from "../../assets/nothing.png";
 
 // LivingBtn 컴포넌트
-const LivingBtn = ({ onChangeSelection, selectedOptions = ["해당없음"] }) => {
-  const [selectedLivingOptions, setSelectedLivingOptions] = useState(selectedOptions);
+const LivingBtn = ({ onChangeSelection, selectedOptions }) => {
+  const [selectedLivingOptions, setSelectedLivingOptions] = useState(
+    selectedOptions.length > 0 ? selectedOptions : ["해당없음"]
+  );
 
   const livingOptions = [
     { img: livingimg1, text: "지체장애" },
@@ -20,12 +22,15 @@ const LivingBtn = ({ onChangeSelection, selectedOptions = ["해당없음"] }) =>
     { img: livingimg6, text: "해당없음" },
   ];
 
+  // 선택 핸들러
   const handleSelect = (text) => {
     if (text === "해당없음") {
       setSelectedLivingOptions(["해당없음"]);
     } else {
       setSelectedLivingOptions((prevOptions) => {
-        const updatedOptions = prevOptions.filter((option) => option !== "해당없음");
+        const updatedOptions = prevOptions.filter(
+          (option) => option !== "해당없음"
+        );
         if (updatedOptions.includes(text)) {
           return updatedOptions.filter((option) => option !== text);
         } else {
@@ -35,25 +40,35 @@ const LivingBtn = ({ onChangeSelection, selectedOptions = ["해당없음"] }) =>
     }
   };
 
+  // 최초 렌더링 시 selectedOptions로 초기화
+  useEffect(() => {
+    if (selectedOptions && selectedOptions.length > 0) {
+      setSelectedLivingOptions(selectedOptions);
+    }
+  }, [selectedOptions]);
+
   // 부모 컴포넌트로 선택된 옵션 전달
   useEffect(() => {
-    if (selectedLivingOptions.length === 0) {
-      setSelectedLivingOptions(["해당없음"]);
+    if (onChangeSelection) {
+      onChangeSelection(selectedLivingOptions);
     }
-    onChangeSelection(selectedLivingOptions);
-  }, [selectedLivingOptions, onChangeSelection]);
+  }, [selectedLivingOptions]);  // 의존성 배열에 onChangeSelection을 포함하지 않음
 
   return (
     <section className="livingbtns">
       {livingOptions.map((option) => (
         <div
           key={option.text}
-          className={`living-btn ${selectedLivingOptions.includes(option.text) ? "selected" : ""}`}
+          className={`living-btn ${
+            selectedLivingOptions.includes(option.text) ? "selected" : ""
+          }`}
           onClick={() => handleSelect(option.text)}
         >
           <img src={option.img} className="living-img" alt={option.text} />
           <div className="living-text">{option.text}</div>
-          {selectedLivingOptions.includes(option.text) && <div className="living-checkmark">✔️</div>}
+          {selectedLivingOptions.includes(option.text) && (
+            <div className="living-checkmark">✔️</div>
+          )}
         </div>
       ))}
     </section>

--- a/frontend/src/components/LivingBtn/LivingBtn.jsx
+++ b/frontend/src/components/LivingBtn/LivingBtn.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
 import "./LivingBtn.css";
-import livingimg1 from "../../assets/physical.png";
-import livingimg2 from "../../assets/visual.png";
-import livingimg3 from "../../assets/hearing.png";
-import livingimg4 from "../../assets/infants.png";
-import livingimg5 from "../../assets/senior.png";
-import livingimg6 from "../../assets/nothing.png";
+import physical_img from "../../assets/physical.png";
+import visual_img from "../../assets/visual.png";
+import hearing_img from "../../assets/hearing.png";
+import infants_img from "../../assets/infants.png";
+import senior_img from "../../assets/senior.png";
+import nothing_img from "../../assets/nothing.png";
 
 // LivingBtn 컴포넌트
 const LivingBtn = ({ onChangeSelection, selectedOptions }) => {
@@ -14,12 +14,12 @@ const LivingBtn = ({ onChangeSelection, selectedOptions }) => {
   );
 
   const livingOptions = [
-    { img: livingimg1, text: "지체장애" },
-    { img: livingimg2, text: "시각장애" },
-    { img: livingimg3, text: "청각장애" },
-    { img: livingimg4, text: "영유아가족" },
-    { img: livingimg5, text: "고령자" },
-    { img: livingimg6, text: "해당없음" },
+    { img: physical_img, text: "지체장애" },
+    { img: visual_img, text: "시각장애" },
+    { img: hearing_img, text: "청각장애" },
+    { img: infants_img, text: "영유아가족" },
+    { img: senior_img, text: "고령자" },
+    { img: nothing_img, text: "해당없음" },
   ];
 
   // 선택 핸들러

--- a/frontend/src/components/LivingBtn/LivingBtn.jsx
+++ b/frontend/src/components/LivingBtn/LivingBtn.jsx
@@ -8,8 +8,8 @@ import livingimg5 from "../../assets/senior.png";
 import livingimg6 from "../../assets/nothing.png";
 
 // LivingBtn 컴포넌트
-const LivingBtn = ({ onChangeSelection }) => {
-  const [selectedLivingOptions, setSelectedLivingOptions] = useState(["해당없음"]); // "해당없음"이 기본 선택
+const LivingBtn = ({ onChangeSelection, selectedOptions = ["해당없음"] }) => {
+  const [selectedLivingOptions, setSelectedLivingOptions] = useState(selectedOptions);
 
   const livingOptions = [
     { img: livingimg1, text: "지체장애" },
@@ -22,34 +22,30 @@ const LivingBtn = ({ onChangeSelection }) => {
 
   const handleSelect = (text) => {
     if (text === "해당없음") {
-      // "해당없음"이 클릭되면 나머지 선택 해제
       setSelectedLivingOptions(["해당없음"]);
     } else {
-      // 다른 옵션이 선택되면 "해당없음" 해제 및 옵션 추가
       setSelectedLivingOptions((prevOptions) => {
-        const updatedOptions = prevOptions.filter(option => option !== "해당없음");
+        const updatedOptions = prevOptions.filter((option) => option !== "해당없음");
         if (updatedOptions.includes(text)) {
-          return updatedOptions.filter(option => option !== text); // 이미 선택된 항목은 해제
+          return updatedOptions.filter((option) => option !== text);
         } else {
-          return [...updatedOptions, text]; // 선택 항목 추가
+          return [...updatedOptions, text];
         }
       });
     }
   };
 
-  // "해당없음"이 자동으로 체크되는 로직
+  // 부모 컴포넌트로 선택된 옵션 전달
   useEffect(() => {
     if (selectedLivingOptions.length === 0) {
       setSelectedLivingOptions(["해당없음"]);
     }
-    if (onChangeSelection) {
-      onChangeSelection(selectedLivingOptions); // 선택 변경 시 부모 컴포넌트에 전달
-    }
+    onChangeSelection(selectedLivingOptions);
   }, [selectedLivingOptions, onChangeSelection]);
 
   return (
     <section className="livingbtns">
-      {livingOptions.map(option => (
+      {livingOptions.map((option) => (
         <div
           key={option.text}
           className={`living-btn ${selectedLivingOptions.includes(option.text) ? "selected" : ""}`}

--- a/frontend/src/components/UserForm/UserForm.jsx
+++ b/frontend/src/components/UserForm/UserForm.jsx
@@ -3,7 +3,7 @@ import Button from "../../components/Button/Button";
 import './UserForm.css';
 import axiosInstance from "../../pages/Login/axiosInstance";
 
-const UserForm = ({ input, onChange, setIsNameValid }) => {
+const UserForm = ({ input, onChange, setIsNameValid, showNicknameCheck }) => {
   const [loading, setLoading] = useState(false); // 중복 검사 요청 상태
 
   const checkNickname = async () => {
@@ -44,13 +44,15 @@ const UserForm = ({ input, onChange, setIsNameValid }) => {
           onChange={onChange}
           placeholder="닉네임을 입력하세요."
         />
-        <div className="nickname-button">
-          <Button
-            text={loading ? "검사 중..." : "중복 검사"}
-            onClick={checkNickname}
-            disabled={loading} // 검사 중에는 버튼 비활성화
-          />
-        </div>
+        {showNicknameCheck && (
+          <div className="nickname-button">
+            <Button
+              text={loading ? "검사 중..." : "중복 검사"}
+              onClick={checkNickname}
+              disabled={loading} // 검사 중에는 버튼 비활성화
+            />
+          </div>
+        )}
       </section>
 
       <section className="birth">

--- a/frontend/src/pages/LivingInfo/LivingInfo.jsx
+++ b/frontend/src/pages/LivingInfo/LivingInfo.jsx
@@ -45,7 +45,7 @@ const LivingInfo = () => {
     <section className="living-page">
       <ProfileInfo text={"여행지 추천에 필요한 생활 정보를 선택해주세요."} src={progressbar2} />
       <section className="living-body">
-        <LivingBtn onChangeSelection={handleLivingSelectionChange} />
+        <LivingBtn onChangeSelection={handleLivingSelectionChange} selectedOptions={selectedOptions} />
         <section>
           <Button text={"다음"} onClick={handleNextClick} />
         </section>

--- a/frontend/src/pages/Mypage/Mypage.jsx
+++ b/frontend/src/pages/Mypage/Mypage.jsx
@@ -14,12 +14,18 @@ const Mypage = () => {
     profileImageUrl: ""
   });
   const [selectedLivingInfo, setSelectedLivingInfo] = useState([]); // 선택된 생활정보 저장
+  const [livingInfoIds, setLivingInfoIds] = useState([]); // 생활정보의 id 저장
   const [loading, setLoading] = useState(true);
   const [livingLoading, setLivingLoading] = useState(true); // 생활정보 로딩 상태
 
+  // livingInfoData를 전역 상태로 정의
+  const [livingInfoData, setLivingInfoData] = useState([]);
+
+  // API 호출로 사용자 정보 가져오기
   useEffect(() => {
     const fetchUserData = async () => {
       try {
+        console.log('사용자 정보 불러오기 시작'); // 콘솔 로그 추가
         const response = await axiosInstance.get('/member/me'); // 사용자 정보 호출
         const userData = response.data;
         setInput({
@@ -29,6 +35,7 @@ const Mypage = () => {
           profileImageUrl: userData.profileImageUrl
         });
         setLoading(false);
+        console.log('사용자 정보 불러오기 완료:', userData); // 콘솔 로그 추가
       } catch (error) {
         console.error('사용자 정보 불러오기 실패:', error);
         setLoading(false);
@@ -41,16 +48,24 @@ const Mypage = () => {
   // 생활정보 불러오기
   useEffect(() => {
     const fetchLivingInfo = async () => {
+      console.log('fetchLivingInfo 함수 실행');
       try {
         const response = await axiosInstance.get('/live/info/member'); // 생활정보 API 호출
+        console.log('생활정보 응답:', response.data); // 콘솔 로그 추가
         const livingInfoData = response.data.liveInfoResponses;
-
+        
         // 선택된 생활정보 필터링
         const selectedInfo = livingInfoData
           .filter(info => info.contain) // 선택된 정보만 필터링
           .map(info => info.name); // 이름만 추출하여 저장
 
+        const selectedInfoIds = livingInfoData
+          .filter(info => info.contain)
+          .map(info => info.liveInfoId); // 선택된 정보의 id 저장
+
+        setLivingInfoData(livingInfoData); // 전역 상태로 저장
         setSelectedLivingInfo(selectedInfo.length > 0 ? selectedInfo : ["해당없음"]); // 선택된 정보가 없으면 "해당없음"
+        setLivingInfoIds(selectedInfoIds); // 선택된 id 값 저장
         setLivingLoading(false);
       } catch (error) {
         console.error('생활정보 불러오기 실패:', error);
@@ -61,6 +76,7 @@ const Mypage = () => {
     fetchLivingInfo();
   }, []);
 
+  // 입력 값 변경 처리 함수
   const onChange = (e) => {
     setInput({
       ...input,
@@ -74,6 +90,33 @@ const Mypage = () => {
 
   const handleLivingSelectionChange = (selectedOptions) => {
     setSelectedLivingInfo(selectedOptions); // 선택된 생활정보 변경
+    // 선택된 옵션에 따라 id 값도 업데이트
+    const updatedLivingIds = livingInfoData
+      .filter(info => selectedOptions.includes(info.name))
+      .map(info => info.liveInfoId);
+    setLivingInfoIds(updatedLivingIds);
+  };
+
+  // 생활정보 수정 (저장) 요청
+  const handleSaveClick = async () => {
+    try {
+      const payload = {
+        liveInfoIds: livingInfoIds.includes("해당없음") ? [] : livingInfoIds, // "해당없음" 선택 시 빈 배열 전송
+      };
+      console.log("저장할 데이터:", payload);
+
+      const response = await axiosInstance.put('/live/info/member', payload);
+
+      if (response.status === 204) {
+        console.log("생활정보 수정 성공");
+        alert("생활정보가 성공적으로 저장되었습니다.");
+      } else {
+        console.error("응답 실패:", response);
+      }
+    } catch (error) {
+      console.error("생활정보 수정 요청 실패:", error);
+      alert("저장 중 문제가 발생했습니다.");
+    }
   };
 
   if (loading || livingLoading) {
@@ -116,7 +159,7 @@ const Mypage = () => {
               selectedOptions={selectedLivingInfo} // 선택된 생활정보 전달
             />
             <section>
-              <Button text={"저장"} />
+              <Button text={"저장"} onClick={handleSaveClick} />
             </section>
           </div>
         )}

--- a/frontend/src/pages/Mypage/Mypage.jsx
+++ b/frontend/src/pages/Mypage/Mypage.jsx
@@ -181,7 +181,7 @@ const Mypage = () => {
             <section className="mypage-img">
               <img src={input.profileImageUrl} className="user-img" alt="User Profile" />
             </section>
-            <UserForm input={input} onChange={onChange} />
+            <UserForm input={input} onChange={onChange} showNicknameCheck={false} />
             <section className="mypage-btn">
               <Button text={savingProfile ? "저장 중..." : "저장"} onClick={handleProfileSaveClick} disabled={savingProfile} />
             </section>

--- a/frontend/src/pages/Mypage/Mypage.jsx
+++ b/frontend/src/pages/Mypage/Mypage.jsx
@@ -3,7 +3,7 @@ import './Mypage.css';
 import LivingBtn from '../../components/LivingBtn/LivingBtn';
 import Button from '../../components/Button/Button';
 import UserForm from "../../components/UserForm/UserForm";
-import UserData from "../../data/UserData";
+import axiosInstance from '../Login/axiosInstance';
 
 const Mypage = () => {
   const [activeTab, setActiveTab] = useState('tab1');
@@ -11,16 +11,33 @@ const Mypage = () => {
     name: "",
     birth: "",
     gender: "",
+    profileImageUrl: ""
   });
+  const [loading, setLoading] = useState(true);
 
+  // API 호출로 사용자 정보 가져오기
   useEffect(() => {
-    setInput({
-      name: UserData.nickname,
-      birth: UserData.birthday,
-      gender: UserData.genderType,
-    });
+    const fetchUserData = async () => {
+      try {
+        const response = await axiosInstance.get('/member/me');
+        const userData = response.data;
+        setInput({
+          name: userData.nickname,
+          birth: userData.birthday,
+          gender: userData.genderType,
+          profileImageUrl: userData.profileImageUrl
+        });
+        setLoading(false);
+      } catch (error) {
+        console.error('사용자 정보 불러오기 실패:', error);
+        setLoading(false);
+      }
+    };
+
+    fetchUserData();
   }, []);
 
+  // 입력 값 변경 처리 함수
   const onChange = (e) => {
     setInput({
       ...input,
@@ -35,6 +52,10 @@ const Mypage = () => {
   const handleLivingSelectionChange = (selectedOptions) => {
     console.log("Selected options:", selectedOptions);
   };
+
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <div className="my-page">
@@ -57,7 +78,7 @@ const Mypage = () => {
         {activeTab === 'tab1' && (
           <div id="tab1">
             <section className="mypage-img">
-              <img src={UserData.profileImageUrl} className="user-img" alt="User Profile" />
+              <img src={input.profileImageUrl} className="user-img" alt="User Profile" />
             </section>
             <UserForm input={input} onChange={onChange} />
             <section className="mypage-btn">

--- a/frontend/src/pages/Mypage/Mypage.jsx
+++ b/frontend/src/pages/Mypage/Mypage.jsx
@@ -17,6 +17,8 @@ const Mypage = () => {
   const [livingInfoIds, setLivingInfoIds] = useState([]); // 생활정보의 id 저장
   const [loading, setLoading] = useState(true);
   const [livingLoading, setLivingLoading] = useState(true); // 생활정보 로딩 상태
+  const [savingProfile, setSavingProfile] = useState(false); // 프로필 저장 중 상태
+  const [savingLivingInfo, setSavingLivingInfo] = useState(false); // 생활정보 저장 중 상태
 
   // livingInfoData를 전역 상태로 정의
   const [livingInfoData, setLivingInfoData] = useState([]);
@@ -98,12 +100,13 @@ const Mypage = () => {
   };
 
   // 생활정보 수정 (저장) 요청
-  const handleSaveClick = async () => {
+  const handleLivingSaveClick = async () => {
+    setSavingLivingInfo(true);
     try {
       const payload = {
         liveInfoIds: livingInfoIds.includes("해당없음") ? [] : livingInfoIds, // "해당없음" 선택 시 빈 배열 전송
       };
-      console.log("저장할 데이터:", payload);
+      console.log("저장할 생활정보 데이터:", payload);
 
       const response = await axiosInstance.put('/live/info/member', payload);
 
@@ -116,6 +119,38 @@ const Mypage = () => {
     } catch (error) {
       console.error("생활정보 수정 요청 실패:", error);
       alert("저장 중 문제가 발생했습니다.");
+    } finally {
+      setSavingLivingInfo(false);
+    }
+  };
+
+  // 프로필 수정 (저장) 요청
+  const handleProfileSaveClick = async () => {
+    setSavingProfile(true);
+    try {
+      const payload = {
+        nickname: input.name,
+        birthday: input.birth,
+        genderType: input.gender,
+        profileImageUrl: input.profileImageUrl
+      };
+      console.log("저장할 프로필 데이터:", payload);
+
+      const response = await axiosInstance.put('/member/profile', payload);
+
+      if (response.status === 204) {
+        console.log("프로필 수정 성공");
+        alert("프로필이 성공적으로 저장되었습니다.");
+      } else if (response.status === 401) {
+        alert("중복된 닉네임이 존재합니다.");
+      } else {
+        console.error("응답 실패:", response);
+      }
+    } catch (error) {
+      console.error("프로필 수정 요청 실패:", error);
+      alert("저장 중 문제가 발생했습니다.");
+    } finally {
+      setSavingProfile(false);
     }
   };
 
@@ -148,7 +183,7 @@ const Mypage = () => {
             </section>
             <UserForm input={input} onChange={onChange} />
             <section className="mypage-btn">
-              <Button text={"저장"} />
+              <Button text={savingProfile ? "저장 중..." : "저장"} onClick={handleProfileSaveClick} disabled={savingProfile} />
             </section>
           </div>
         )}
@@ -159,7 +194,7 @@ const Mypage = () => {
               selectedOptions={selectedLivingInfo} // 선택된 생활정보 전달
             />
             <section>
-              <Button text={"저장"} onClick={handleSaveClick} />
+              <Button text={savingLivingInfo ? "저장 중..." : "저장"} onClick={handleLivingSaveClick} disabled={savingLivingInfo} />
             </section>
           </div>
         )}

--- a/frontend/src/pages/Mypage/Mypage.jsx
+++ b/frontend/src/pages/Mypage/Mypage.jsx
@@ -13,13 +13,14 @@ const Mypage = () => {
     gender: "",
     profileImageUrl: ""
   });
+  const [selectedLivingInfo, setSelectedLivingInfo] = useState([]); // 선택된 생활정보 저장
   const [loading, setLoading] = useState(true);
+  const [livingLoading, setLivingLoading] = useState(true); // 생활정보 로딩 상태
 
-  // API 호출로 사용자 정보 가져오기
   useEffect(() => {
     const fetchUserData = async () => {
       try {
-        const response = await axiosInstance.get('/member/me');
+        const response = await axiosInstance.get('/member/me'); // 사용자 정보 호출
         const userData = response.data;
         setInput({
           name: userData.nickname,
@@ -37,7 +38,29 @@ const Mypage = () => {
     fetchUserData();
   }, []);
 
-  // 입력 값 변경 처리 함수
+  // 생활정보 불러오기
+  useEffect(() => {
+    const fetchLivingInfo = async () => {
+      try {
+        const response = await axiosInstance.get('/live/info/member'); // 생활정보 API 호출
+        const livingInfoData = response.data.liveInfoResponses;
+
+        // 선택된 생활정보 필터링
+        const selectedInfo = livingInfoData
+          .filter(info => info.contain) // 선택된 정보만 필터링
+          .map(info => info.name); // 이름만 추출하여 저장
+
+        setSelectedLivingInfo(selectedInfo.length > 0 ? selectedInfo : ["해당없음"]); // 선택된 정보가 없으면 "해당없음"
+        setLivingLoading(false);
+      } catch (error) {
+        console.error('생활정보 불러오기 실패:', error);
+        setLivingLoading(false);
+      }
+    };
+
+    fetchLivingInfo();
+  }, []);
+
   const onChange = (e) => {
     setInput({
       ...input,
@@ -50,10 +73,10 @@ const Mypage = () => {
   };
 
   const handleLivingSelectionChange = (selectedOptions) => {
-    console.log("Selected options:", selectedOptions);
+    setSelectedLivingInfo(selectedOptions); // 선택된 생활정보 변경
   };
 
-  if (loading) {
+  if (loading || livingLoading) {
     return <div>로딩 중...</div>;
   }
 
@@ -88,7 +111,10 @@ const Mypage = () => {
         )}
         {activeTab === 'tab2' && (
           <div id="tab2" className='mypage-living'>
-            <LivingBtn onChangeSelection={handleLivingSelectionChange} />
+            <LivingBtn 
+              onChangeSelection={handleLivingSelectionChange} 
+              selectedOptions={selectedLivingInfo} // 선택된 생활정보 전달
+            />
             <section>
               <Button text={"저장"} />
             </section>
@@ -97,6 +123,6 @@ const Mypage = () => {
       </section>
     </div>
   );
-}
+};
 
 export default Mypage;

--- a/frontend/src/pages/Profile/Profile.jsx
+++ b/frontend/src/pages/Profile/Profile.jsx
@@ -112,7 +112,7 @@ const Profile = () => {
       <ProfileInfo text={"회원가입을 위해 프로필 정보를 입력해주세요."} src={progressbar} />
 
       <section className="profile-body">
-        <UserForm input={input} onChange={onChange} setIsNameValid={setIsNameValid} />
+        <UserForm input={input} onChange={onChange} setIsNameValid={setIsNameValid} showNicknameCheck={true} />
 
         <section className="profile-btn">
           <Button

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    port: 3000, // 포트 번호 설정
+  },
+});


### PR DESCRIPTION
## 관련 IssueNumber

> #236

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 마이페이지 연동작업을 진행했습니다.
- 프로필탭에서 중복검사 버튼을 누르면 403 에러가 뜨는 문제가 있어 확인해보니 최초입력1 페이지의 api를 사용하고 있던 문제를 발견했습니다. 이미 프로필탭에서 저장 버튼을 통해 닉네임의 중복여부를 확인하는 api가 있어 중복검사 버튼을 제거하였습니다.
- 생활탭에서 고령인 버튼을 누르면 저장이 되지 않는 문제가 있었습니다. 확인해보니 고령인이 아니라 고령자로 get이 되고 있어서 생기는 문제인 것을 파악하였고 고령자로 이름을 변경하였습니다.
- 프로필탭에서 카카오톡프로필의 사진과 최초회원가입시 입력한 닉네임, 생년월일, 성별 정보가 잘 불러와지는 것을 확인했고, 수정 후 저장버튼을 통해 업데이트되는 부분도 잘 작동하는 것을 확인했습니다.
- 생활탭에서도 true 값인 생활정보의 버튼이 클릭상태로 보여지는 것을 확인했고, 다른 버튼을 누르고 저장 시 해당 정보로 업데이트되는 것을 확인했습니다.
