### PR TITLE
[test] 회원 상태 체크 및 헤더 상태 제공 API 테스트 코드 보강 

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -27,6 +27,28 @@ include::{snippets}/member/find/authority/profile/success/init/http-response.ado
 
 include::{snippets}/member/find/authority/profile/success/init/response-fields.adoc[]
 
+=== 회원 권한과 프로필 이미지 경로 찾는 API (권한: 정규 유저)
+
+==== HTTP Request
+
+include::{snippets}/member/find/authority/profile/success/regular/http-request.adoc[]
+
+===== Request Header
+
+include::{snippets}/member/find/authority/profile/success/regular/request-headers.adoc[]
+
+===== Request Body
+
+include::{snippets}/member/find/authority/profile/success/regular/request-body.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member/find/authority/profile/success/regular/http-response.adoc[]
+
+===== Response Body
+
+include::{snippets}/member/find/authority/profile/success/regular/response-fields.adoc[]
+
 === 회원 정보 조회(마이페이지) API
 
 ==== HTTP Request

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -49,6 +49,24 @@ include::{snippets}/member/find/authority/profile/success/regular/http-response.
 
 include::{snippets}/member/find/authority/profile/success/regular/response-fields.adoc[]
 
+=== 회원 권한과 프로필 이미지 경로 찾는 API (권한: 비회원)
+
+==== HTTP Request
+
+include::{snippets}/member/find/authority/profile/fail/http-request.adoc[]
+
+===== Request Header
+
+include::{snippets}/member/find/authority/profile/fail/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member/find/authority/profile/fail/http-response.adoc[]
+
+===== Response Body
+
+include::{snippets}/member/find/authority/profile/fail/response-body.adoc[]
+
 === 회원 정보 조회(마이페이지) API
 
 ==== HTTP Request

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -1,9 +1,31 @@
-== ⛳️ Member (회원) 마이페이지
+== ⛳️ Member (회원) 마이페이지 + Header 조회
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
 :toclevels: 2
+
+=== 회원 권한과 프로필 이미지 경로 찾는 API (권한: 최초 회원가입 유저)
+
+==== HTTP Request
+
+include::{snippets}/member/find/authority/profile/success/init/http-request.adoc[]
+
+===== Request Header
+
+include::{snippets}/member/find/authority/profile/success/init/request-headers.adoc[]
+
+===== Request Body
+
+include::{snippets}/member/find/authority/profile/success/init/request-body.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member/find/authority/profile/success/init/http-response.adoc[]
+
+===== Response Body
+
+include::{snippets}/member/find/authority/profile/success/init/response-fields.adoc[]
 
 === 회원 정보 조회(마이페이지) API
 
@@ -194,3 +216,4 @@ include::{snippets}/live/info/member/update/fail/noExistMember/http-response.ado
 ===== Response Body
 
 include::{snippets}/live/info/member/update/fail/noExistMember/response-body.adoc[]
+

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -13,6 +13,7 @@ import moheng.member.dto.request.SignUpInterestTripsRequest;
 import moheng.member.dto.request.SignUpLiveInfoRequest;
 import moheng.member.dto.request.SignUpProfileRequest;
 import moheng.member.dto.request.UpdateProfileRequest;
+import moheng.member.dto.response.FindMemberAuthorityAndProfileResponse;
 import moheng.member.dto.response.MemberResponse;
 import moheng.member.exception.DuplicateNicknameException;
 import moheng.member.exception.NoExistMemberException;
@@ -163,5 +164,19 @@ public class MemberService {
 
     private boolean isAlreadyExistNickname(final String nickname) {
         return memberRepository.existsByNickName(nickname);
+    }
+
+    public FindMemberAuthorityAndProfileResponse findMemberAuthorityAndProfileImg(final long memberId) {
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(NoExistMemberException::new);
+
+        return findMemberAuthorityAndProfileImg(member);
+    }
+
+    private FindMemberAuthorityAndProfileResponse findMemberAuthorityAndProfileImg(final Member member) {
+        if(member.getAuthority().equals(Authority.REGULAR_MEMBER)) {
+            return new FindMemberAuthorityAndProfileResponse(member.getAuthority(), member.getProfileImageUrl());
+        }
+        return new FindMemberAuthorityAndProfileResponse(member.getAuthority(), null);
     }
 }

--- a/backend/src/main/java/moheng/member/application/MemberService.java
+++ b/backend/src/main/java/moheng/member/application/MemberService.java
@@ -169,7 +169,6 @@ public class MemberService {
     public FindMemberAuthorityAndProfileResponse findMemberAuthorityAndProfileImg(final long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(NoExistMemberException::new);
-
         return findMemberAuthorityAndProfileImg(member);
     }
 

--- a/backend/src/main/java/moheng/member/dto/response/FindMemberAuthorityAndProfileResponse.java
+++ b/backend/src/main/java/moheng/member/dto/response/FindMemberAuthorityAndProfileResponse.java
@@ -1,0 +1,24 @@
+package moheng.member.dto.response;
+
+import moheng.auth.domain.oauth.Authority;
+
+public class FindMemberAuthorityAndProfileResponse {
+    private Authority authority;
+    private String profileImageUrl;
+
+    private FindMemberAuthorityAndProfileResponse() {
+    }
+
+    public FindMemberAuthorityAndProfileResponse(final Authority authority, final String profileImageUrl) {
+        this.authority = authority;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public Authority getAuthority() {
+        return authority;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/backend/src/main/java/moheng/member/presentation/MemberController.java
+++ b/backend/src/main/java/moheng/member/presentation/MemberController.java
@@ -6,6 +6,7 @@ import moheng.auth.presentation.initauthentication.InitAuthentication;
 import moheng.member.application.MemberService;
 import moheng.member.dto.request.*;
 import moheng.member.dto.response.CheckDuplicateNicknameResponse;
+import moheng.member.dto.response.FindMemberAuthorityAndProfileResponse;
 import moheng.member.dto.response.MemberResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -60,5 +61,10 @@ public class MemberController {
             @RequestBody final UpdateProfileRequest request) {
         memberService.updateByProfile(accessor.getId(), request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/authority/profile")
+    public ResponseEntity<FindMemberAuthorityAndProfileResponse> findMemberAuthorityAndProfileImg(@Authentication final Accessor accessor) {
+        return ResponseEntity.ok(memberService.findMemberAuthorityAndProfileImg(accessor.getId()));
     }
 }

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Component
 public class ExternalAiRecommendModelClient implements ExternalRecommendModelClient {
-    private static final String RECOMMEND_TRIP_LIST_REQUEST_URL = "http://localhost:8000/travel/custom/model?page=1";
+    private static final String RECOMMEND_TRIP_LIST_REQUEST_URL = "http://localhost:8000/travel/custom/model?page={page}";
     private final RestTemplate restTemplate;
 
     public ExternalAiRecommendModelClient(final RestTemplate restTemplate) {
@@ -37,7 +37,8 @@ public class ExternalAiRecommendModelClient implements ExternalRecommendModelCli
                 RECOMMEND_TRIP_LIST_REQUEST_URL,
                 HttpMethod.POST,
                 new HttpEntity<>(new PreferredLocationRequest(request.getPreferredLocation())),
-                RecommendTripsByVisitedLogsResponse.class
+                RecommendTripsByVisitedLogsResponse.class,
+                uriVariables
         );
 
         if(responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 @Component
 public class ExternalAiSimilarTripModelClient implements ExternalSimilarTripModelClient {
-    private static final String SIMILAR_TRIP_LIST_REQUEST_URL = "http://localhost:8000/travel/similar/{contentId}/{page}";
+    private static final String SIMILAR_TRIP_LIST_REQUEST_URL = "http://localhost:8000/travel/similar/{contentId}?page={page}";
     private final RestTemplate restTemplate;
 
     public ExternalAiSimilarTripModelClient(final RestTemplate restTemplate) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
     name: moheng
   datasource:
     username: root
-    url: jdbc:mysql://localhost:3306/moheng
-    # jdbc:h2:mem:~/moheng;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE
+    url: jdbc:h2:mem:~/moheng;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE
+    # jdbc:mysql://localhost:3306/moheng
     password: 1234
   lifecycle:
     timeout-per-shutdown-phase: 20s

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,8 @@ spring:
     name: moheng
   datasource:
     username: root
-    url: jdbc:h2:mem:~/moheng;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE
+    url: jdbc:mysql://localhost:3306/moheng
+    # jdbc:h2:mem:~/moheng;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=FALSE
     password: 1234
   lifecycle:
     timeout-per-shutdown-phase: 20s

--- a/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
@@ -201,14 +201,7 @@ public class MemberAcceptanceTest extends AcceptanceTestConfig {
         AccessTokenResponse accessTokenResponse = loginResponse.as(AccessTokenResponse.class);
 
         // when
-        ExtractableResponse<Response> memberResponse = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2(accessTokenResponse.getAccessToken())
-                .when().get("/api/member/authority/profile")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
-
+        ExtractableResponse<Response> memberResponse = 회원_권한과_프로필을_찾는다(accessTokenResponse.getAccessToken());
         FindMemberAuthorityAndProfileResponse responseResult = memberResponse.as(FindMemberAuthorityAndProfileResponse.class);
 
         assertAll(() -> {

--- a/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/moheng/acceptance/MemberAcceptanceTest.java
@@ -11,14 +11,23 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import moheng.acceptance.config.AcceptanceTestConfig;
+import moheng.auth.domain.oauth.Authority;
 import moheng.auth.dto.AccessTokenResponse;
 import moheng.liveinformation.dto.FindMemberLiveInformationResponses;
+import moheng.member.domain.GenderType;
+import moheng.member.dto.request.UpdateProfileRequest;
+import moheng.member.dto.response.FindMemberAuthorityAndProfileResponse;
 import moheng.member.dto.response.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
 
 public class MemberAcceptanceTest extends AcceptanceTestConfig {
 
@@ -181,6 +190,31 @@ public class MemberAcceptanceTest extends AcceptanceTestConfig {
             assertThat(profileResponse.getProfileImageUrl()).isNotNull();
             assertThat(profileResponse.getGenderType()).isNotNull();
             assertThat(memberLiveInformationResponses.getLiveInfoResponses()).hasSize(5);
+        });
+    }
+
+    @DisplayName("멤버의 등급과 프로필 이미지 경로를 찾고 상태코드 200을 리턴한다.")
+    @Test
+    void 멤버의_등급과_프로필_이미지_경로를_찾고_상태코드_200을_리턴한다() {
+        // given
+        ExtractableResponse<Response> loginResponse = 자체_토큰을_생성한다("KAKAO", "authorization-code");
+        AccessTokenResponse accessTokenResponse = loginResponse.as(AccessTokenResponse.class);
+
+        // when
+        ExtractableResponse<Response> memberResponse = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(accessTokenResponse.getAccessToken())
+                .when().get("/api/member/authority/profile")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        FindMemberAuthorityAndProfileResponse responseResult = memberResponse.as(FindMemberAuthorityAndProfileResponse.class);
+
+        assertAll(() -> {
+            assertThat(responseResult.getAuthority()).isEqualTo(Authority.INIT_MEMBER);
+            assertThat(responseResult.getProfileImageUrl()).isNull();
+            assertThat(memberResponse.statusCode()).isEqualTo(200);
         });
     }
 }

--- a/backend/src/test/java/moheng/acceptance/fixture/MemberAcceptanceFixture.java
+++ b/backend/src/test/java/moheng/acceptance/fixture/MemberAcceptanceFixture.java
@@ -56,4 +56,14 @@ public class MemberAcceptanceFixture {
                 .statusCode(org.springframework.http.HttpStatus.NO_CONTENT.value())
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 회원_권한과_프로필을_찾는다(final String accessToken) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(accessToken)
+                .when().get("/api/member/authority/profile")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
 }

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -540,4 +540,17 @@ public class MemberServiceTest extends ServiceTestConfig {
         // then
         assertThat(actual.getProfileImageUrl()).isNotNull();
     }
+
+    @DisplayName("멤버의 등급이 최초 회원이라면 프로필 이미지가 아닌 null 을 리턴한다.")
+    @Test
+    void 멤버의_등급이_최초_회원이라면_프로필_이미지가_아닌_null_을_리턴한다() {
+        // given
+        Member member = memberRepository.save(하온_신규());
+
+        // when
+        FindMemberAuthorityAndProfileResponse actual = memberService.findMemberAuthorityAndProfileImg(member.getId());
+
+        // then
+        assertThat(actual.getProfileImageUrl()).isNull();
+    }
 }

--- a/backend/src/test/java/moheng/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/moheng/member/application/MemberServiceTest.java
@@ -20,6 +20,7 @@ import moheng.member.dto.request.SignUpInterestTripsRequest;
 import moheng.member.dto.request.SignUpLiveInfoRequest;
 import moheng.member.dto.request.SignUpProfileRequest;
 import moheng.member.dto.request.UpdateProfileRequest;
+import moheng.member.dto.response.FindMemberAuthorityAndProfileResponse;
 import moheng.member.exception.DuplicateNicknameException;
 import moheng.member.exception.NoExistMemberException;
 import moheng.member.exception.ShortContentidsSizeException;
@@ -526,4 +527,17 @@ public class MemberServiceTest extends ServiceTestConfig {
         );
     }
 
+    @DisplayName("멤버의 등급이 정규 회원이라면 프로필 이미지를 리턴한다.")
+    @Test
+    void 멤버의_등급이_정규_회원이라면_프로필_이미지를_리턴한다() {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        member.changePrivilege(Authority.REGULAR_MEMBER);
+
+        // when
+        FindMemberAuthorityAndProfileResponse actual = memberService.findMemberAuthorityAndProfileImg(member.getId());
+
+        // then
+        assertThat(actual.getProfileImageUrl()).isNotNull();
+    }
 }

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -8,6 +8,7 @@ import moheng.auth.exception.InvalidOAuthServiceException;
 import moheng.config.slice.ControllerTestConfig;
 import moheng.liveinformation.exception.EmptyLiveInformationException;
 import moheng.liveinformation.exception.NoExistLiveInformationException;
+import moheng.member.dto.response.FindMemberAuthorityAndProfileResponse;
 import moheng.member.exception.*;
 import moheng.trip.exception.NoExistTripException;
 import org.junit.jupiter.api.DisplayName;
@@ -568,5 +569,28 @@ public class MemberControllerTest extends ControllerTestConfig {
                                 fieldWithPath("contentIds").description("관심 여행지의 contentId 리스트")
                         ))
                 ).andExpect(status().isNotFound());
+    }
+
+    @DisplayName("정규 멤버의 등급과 프로필 이미지를 찾고 상태코드 200을 리턴한다.")
+    @Test
+    void 정규_멤버의_등급과_프로필_이미지를_찾고_상태코드_200을_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberService.findMemberAuthorityAndProfileImg(anyLong()))
+                .willReturn(new FindMemberAuthorityAndProfileResponse(Authority.REGULAR_MEMBER, "https://kakao.png"));
+
+        // when, then
+        mockMvc.perform(get("/api/member/authority/profile")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andDo(document("member/find/authority/profile/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("엑세스 토큰")
+                        ))
+                ).andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -3,6 +3,7 @@ package moheng.member.presentation;
 import static moheng.fixture.MemberFixtures.*;
 
 import moheng.auth.domain.oauth.Authority;
+import moheng.auth.exception.EmptyBearerHeaderException;
 import moheng.auth.exception.InvalidInitAuthorityException;
 import moheng.auth.exception.InvalidOAuthServiceException;
 import moheng.config.slice.ControllerTestConfig;
@@ -623,5 +624,28 @@ public class MemberControllerTest extends ControllerTestConfig {
                                 fieldWithPath("profileImageUrl").description("null - 최초 회원의 프로필 이미지 경로 ")
                         ))
                 ).andExpect(status().isOk());
+    }
+
+    @DisplayName("비회원의 등급과 프로필 이미지를 찾으면 상태코드 401을 리턴한다.")
+    @Test
+    void 비회원의_등급과_프로필_이미지를_찾으면_상태코드_401을_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        doThrow(new EmptyBearerHeaderException("Authorization Bearer 해더 값이 비어있습니다."))
+                .when(memberService).findMemberAuthorityAndProfileImg(anyLong());
+
+        // when, then
+        mockMvc.perform(get("/api/member/authority/profile")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andDo(document("member/find/authority/profile/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("엑세스 토큰")
+                        ))
+                ).andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -590,6 +590,10 @@ public class MemberControllerTest extends ControllerTestConfig {
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
                                 headerWithName("Authorization").description("엑세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("authority").description("정규 회원의 권한 (정규 멤버 권한)"),
+                                fieldWithPath("profileImageUrl").description("정규 회원의 프로필 이미지 경로")
                         ))
                 ).andExpect(status().isOk());
     }

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -597,4 +597,31 @@ public class MemberControllerTest extends ControllerTestConfig {
                         ))
                 ).andExpect(status().isOk());
     }
+
+    @DisplayName("최초 멤버의 등급과 프로필 이미지를 찾고 상태코드 200을 리턴한다.")
+    @Test
+    void 최초_멤버의_등급과_프로필_이미지를_찾고_상태코드_200을_리턴한다() throws Exception {
+        // given
+        given(jwtTokenProvider.getMemberId(anyString())).willReturn(1L);
+        given(memberService.findMemberAuthorityAndProfileImg(anyLong()))
+                .willReturn(new FindMemberAuthorityAndProfileResponse(Authority.INIT_MEMBER, null));
+
+        // when, then
+        mockMvc.perform(get("/api/member/authority/profile")
+                        .header("Authorization", "Bearer aaaaaa.bbbbbb.cccccc")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andDo(document("member/find/authority/profile/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName("Authorization").description("엑세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("authority").description("최초 회원의 권한 (정규 멤버 권한)"),
+                                fieldWithPath("profileImageUrl").description("null - 최초 회원의 프로필 이미지 경로 ")
+                        ))
+                ).andExpect(status().isOk());
+    }
 }

--- a/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/moheng/member/presentation/MemberControllerTest.java
@@ -586,14 +586,14 @@ public class MemberControllerTest extends ControllerTestConfig {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
-                .andDo(document("member/find/authority/profile/success",
+                .andDo(document("member/find/authority/profile/success/regular",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
                                 headerWithName("Authorization").description("엑세스 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("authority").description("정규 회원의 권한 (정규 멤버 권한)"),
+                                fieldWithPath("authority").description("정규 회원의 권한"),
                                 fieldWithPath("profileImageUrl").description("정규 회원의 프로필 이미지 경로")
                         ))
                 ).andExpect(status().isOk());
@@ -613,14 +613,14 @@ public class MemberControllerTest extends ControllerTestConfig {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
-                .andDo(document("member/find/authority/profile/success",
+                .andDo(document("member/find/authority/profile/success/init",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(
                                 headerWithName("Authorization").description("엑세스 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("authority").description("최초 회원의 권한 (정규 멤버 권한)"),
+                                fieldWithPath("authority").description("최초 회원의 권한)"),
                                 fieldWithPath("profileImageUrl").description("null - 최초 회원의 프로필 이미지 경로 ")
                         ))
                 ).andExpect(status().isOk());
@@ -640,7 +640,7 @@ public class MemberControllerTest extends ControllerTestConfig {
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
-                .andDo(document("member/find/authority/profile/success",
+                .andDo(document("member/find/authority/profile/fail",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestHeaders(


### PR DESCRIPTION
## 관련 IssueNumber

> #319 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 비회원, 최초 회원가입 유저, 정규 회원을 구분지어서 UI 상에 별도 이미지 및 상태값을 표시해야합니다. 이를 위한 기능을 구현했습니다.
