### PR TITLE
[hotfix] gradlew clean build 명령어로 변경

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -14,5 +14,6 @@ RUN chmod +x ./gradlew \
 # 소스코드 복사
 COPY src /app/src
 
+RUN ./gradlew clean build
 # CMD ["tail", "-f"]
 CMD ["./gradlew", "bootRun"]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -15,7 +15,7 @@ RUN chmod +x ./gradlew \
 COPY src /app/src
 
 # 소스코드 빌드
-RUN ./gradlew build
+RUN ./gradlew clean build
 
 # --------------------------------------------------------------------
 # 최종 이미지

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -24,6 +24,8 @@ services:
     restart: always
     environment:
       - LOGGING_LEVEL_ROOT=ERROR
+    volumes:
+      - ./back-dir:/usr/app
 
   frontend:
     container_name: front
@@ -66,6 +68,12 @@ volumes:
       type: none
       o: bind
       device: ./ai
+  back-dir:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./backend
 
 networks:
   moheng-network:


### PR DESCRIPTION
## 관련 IssueNumber

> #325 


## 변경사항

- 빌드 캐시가 남아서 업데이트가 되지않는 문제를 발견하여 backend gradlew clean build 로 변경하였습니다.
