### PR TITLE
[feat] 로그인여부에 따른 헤더 구조 변경

### DIFF
--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -1,34 +1,53 @@
 import React, { useState, useEffect } from 'react';
+import axiosInstance from '../../pages/Login/axiosInstance'; // axiosInstance를 import
 import logo from '../../assets/logo.png';
 import "./Header.css";
 import { Link } from 'react-router-dom';
-import profileimg from "../../assets/profileimg.png" //예시로 넣어 볼 프로필 이미지
+import profileimg from "../../assets/profileimg.png"; // 예시로 넣어 볼 프로필 이미지
 
 const Header = () => {
-  // 로그인 상태와 사용자 정보를 관리할 상태 변수
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [isFirstLogin, setIsFirstLogin] = useState(true); // 최초 로그인 여부
-  const [profileImg, setProfileImg] = useState(null); // 프로필 이미지 경로
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 여부 상태
+  const [isFirstLogin, setIsFirstLogin] = useState(false); // 최초 로그인 여부 상태
+  const [profileImg, setProfileImg] = useState(profileimg); // 기본 프로필 이미지로 설정
+  const [loading, setLoading] = useState(true); // 로딩 상태
 
   useEffect(() => {
-    // 1: 로그인 전
-    setIsLoggedIn(false);
-    setIsFirstLogin(true);
+    const fetchUserProfile = async () => {
+      try {
+        // API 호출
+        const response = await axiosInstance.get('/member/authority/profile');
+        const { authority, profileImageUrl } = response.data;
 
-    // 2: 최초 로그인 (회원가입 후 프로필 설정 단계) /signup/profile , /signup/livinginfo, /signup/interestedplace 페이지에서의 헤더
-    // setIsLoggedIn(true);
-    // setIsFirstLogin(true);
+        if (authority === 'INIT_MEMBER') {
+          setIsLoggedIn(true);
+          setIsFirstLogin(true); // 최초 로그인 상태로 설정
+        } else if (authority === 'REGULAR_MEMBER') {
+          setIsLoggedIn(true);
+          setIsFirstLogin(false); // 정규 회원 상태
+          setProfileImg(profileImageUrl || profileimg); // 프로필 이미지 설정 (없으면 기본 이미지)
+        }
+      } catch (error) {
+        if (error.response && error.response.status === 401) {
+          setIsLoggedIn(false); // 비회원 상태
+        } else {
+          console.error('API 호출 중 오류 발생:', error);
+        }
+      } finally {
+        setLoading(false); // 로딩 상태 종료
+      }
+    };
 
-    // 3: 로그인 후 (프로필 설정 완료)
-    // setIsLoggedIn(true);
-    // setIsFirstLogin(false);
-    // setProfileImg(profileimg);
-  }, []); // 빈 배열을 넣어 useEffect가 컴포넌트 마운트 시 한 번만 실행되도록 함
+    fetchUserProfile();
+  }, []);
+
+  if (loading) {
+    return null; // 로딩 중일 때는 아무것도 렌더링하지 않음
+  }
 
   return (
     <section className='header'>
       <Link to='/'>
-        <img src={logo} className='logo-img' />
+        <img src={logo} className='logo-img' alt="Logo" />
       </Link>
       <div className='moheng'>모행</div>
 

--- a/frontend/src/pages/Login/axiosInstance.jsx
+++ b/frontend/src/pages/Login/axiosInstance.jsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
-  baseURL: "https://moheng.xyz/api",
+  baseURL: "http://localhost:8080/api",
 });
 
 // 요청 인터셉터: 엑세스 토큰을 요청 헤더에 추가

--- a/frontend/src/pages/Login/axiosInstance.jsx
+++ b/frontend/src/pages/Login/axiosInstance.jsx
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
-  baseURL: "http://localhost:8080/api",
+  baseURL: `${import.meta.env.VITE_SERVER_URL}/api`,
 });
 
 // 요청 인터셉터: 엑세스 토큰을 요청 헤더에 추가


### PR DESCRIPTION
## 관련 IssueNumber

> #242

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 로그인 여부에 따라 헤더 구조가 변경되도록 하였습니다.
- 하지만 수정해야 할 부분이 몇 군데 있어 구현이 필요합니다. 현재 메인페이지연동작업이 가장 중요해서 해당 부분을 먼저 진행하도록 하겠습니다.

[수정해야 할 부분]
- 프로필이미지 동그랗게하고 드롭다운 맨 위에 보이도록 하기
- 새로고침해야 헤더가 바뀌는데 렌더링될 때 헤더가 바로 바뀌도록 해야 합니다.
