### PR TITLE
[fix] 키워드 필터링 맞춤 추천 여행지 조회시 빈 배열일 때 여행지가 조회되지 않는 현상 해결 

### DIFF
--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -63,14 +63,18 @@ public class KeywordService {
 
     public FindTripsResponse findRecommendTripsByKeywords(final TripsByKeyWordsRequest request) {
         if (request.getKeywordIds().isEmpty()) {
-            final Keyword randomKeyword = randomKeywordGeneratable.generate();
-            final List<TripKeyword> tripKeywords = tripKeywordRepository.findTop30ByKeywordId(randomKeyword.getId());
-            final List<Trip> topTrips = tripsByStatisticsFinder.findTripsWithVisitedCount(tripKeywords);
-            return new FindTripsResponse(extractAllTripKeywordsByTopTrips(topTrips));
+            return findRecommendTripsByEmptyKeyword();
         }
         validateKeywords(request.getKeywordIds());
         final List<TripKeyword> trips = filterTop30Trips(tripKeywordRepository.findTripKeywordsByKeywordIds(request.getKeywordIds()));
         return new FindTripsResponse(trips);
+    }
+
+    private FindTripsResponse findRecommendTripsByEmptyKeyword() {
+        final Keyword randomKeyword = randomKeywordGeneratable.generate();
+        final List<TripKeyword> tripKeywords = tripKeywordRepository.findTop30ByKeywordId(randomKeyword.getId());
+        final List<Trip> topTrips = tripsByStatisticsFinder.findTripsWithVisitedCount(tripKeywords);
+        return new FindTripsResponse(extractAllTripKeywordsByTopTrips(topTrips));
     }
 
     private List<TripKeyword> filterTop30Trips(final List<TripKeyword> trips) {

--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -62,6 +62,12 @@ public class KeywordService {
     }
 
     public FindTripsResponse findRecommendTripsByKeywords(final TripsByKeyWordsRequest request) {
+        if (request.getKeywordIds().isEmpty()) {
+            final Keyword randomKeyword = randomKeywordGeneratable.generate();
+            final List<TripKeyword> tripKeywords = tripKeywordRepository.findTop30ByKeywordId(randomKeyword.getId());
+            final List<Trip> topTrips = tripsByStatisticsFinder.findTripsWithVisitedCount(tripKeywords);
+            return new FindTripsResponse(extractAllTripKeywordsByTopTrips(topTrips));
+        }
         validateKeywords(request.getKeywordIds());
         final List<TripKeyword> trips = filterTop30Trips(tripKeywordRepository.findTripKeywordsByKeywordIds(request.getKeywordIds()));
         return new FindTripsResponse(trips);

--- a/backend/src/main/java/moheng/keyword/application/KeywordService.java
+++ b/backend/src/main/java/moheng/keyword/application/KeywordService.java
@@ -66,8 +66,9 @@ public class KeywordService {
             return findRecommendTripsByEmptyKeyword();
         }
         validateKeywords(request.getKeywordIds());
-        final List<TripKeyword> trips = filterTop30Trips(tripKeywordRepository.findTripKeywordsByKeywordIds(request.getKeywordIds()));
-        return new FindTripsResponse(trips);
+        final List<TripKeyword> tripKeywords = filterTop30Trips(tripKeywordRepository.findTripKeywordsByKeywordIds(request.getKeywordIds()));
+        final List<Trip> topTrips = tripsByStatisticsFinder.findTripsWithVisitedCount(tripKeywords);
+        return new FindTripsResponse(extractAllTripKeywordsByTopTrips(topTrips));
     }
 
     private FindTripsResponse findRecommendTripsByEmptyKeyword() {

--- a/backend/src/main/resources/json/trip2.json
+++ b/backend/src/main/resources/json/trip2.json
@@ -15092,7 +15092,7 @@
   {
     "contentid": "2674680",
     "title": "김포 평화문화관",
-    "firstimage": "",
+    "firstimage": "http://tong.visitkorea.or.kr/cms/resource/82/2023282_image2_1.jp",
     "addr1": "경기도 김포시 월곶면 용강로13번길 38",
     "mapx": "126.5522167339",
     "mapy": "37.7208564685",


### PR DESCRIPTION
## 관련 IssueNumber

> #339 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 키워드 필터링 맞춤 추천 여행지 조회시 빈 배열일 때 여행지가 조회되지 않는 현상 해결 
