### PR TITLE
[fix] asciidoctor 테스크의 의존성을 build 테스크에 의존하도록 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -133,17 +133,12 @@ asciidoctor {
 	sources {
 		include("**/index.adoc")
 	}
-	// 경로를 baseDir로 맞춰준다!
 	baseDirFollowsSourceFile()
 }
 
-// bootJar {
-	// dependsOn asciidoctor
-	// copy {
-	// 	from "${asciidoctor.outputDir}"
-	// 	into 'src/main/resources/static/docs'
-	// }
-// }
+tasks.named('build') {
+	dependsOn asciidoctor
+}
 
 sonar {
 	properties {

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -701,7 +701,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: refresh-token=refresh-token; Path=/; Max-Age=604800; Expires=Wed, 18 Sep 2024 15:09:36 GMT; Secure; HttpOnly; SameSite=None
+Set-Cookie: refresh-token=refresh-token; Path=/; Max-Age=604800; Expires=Sun, 22 Sep 2024 13:42:28 GMT; Secure; HttpOnly; SameSite=None
 Content-Type: application/json
 Content-Length: 36
 
@@ -7370,8 +7370,14 @@ Vary: Access-Control-Request-Headers</code></pre>
 <h3 id="_세부_일정내의_특정_여행지_삭제_api_실패_존재하지_않는_여행지를_삭제하려는_경우">세부 일정내의 특정 여행지 삭제 API 실패 (존재하지 않는 여행지를 삭제하려는 경우)</h3>
 <div class="sect3">
 <h4 id="_http_request_71">HTTP Request</h4>
-<div class="paragraph">
-<p>Unresolved directive in tripschedule.adoc - include::/Users/goorm/Desktop/moheng/backend/build/generated-snippets/planner/schedule/trip/delete/http-request.adoc[]</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/schedule/1/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer aaaaaa.bbbbbb.cccccc
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_request_path_variable_16">Request Path Variable</h5>
@@ -7401,26 +7407,58 @@ Vary: Access-Control-Request-Headers</code></pre>
 </div>
 <div class="sect4">
 <h5 id="_request_header_59">Request Header</h5>
-<div class="paragraph">
-<p>Unresolved directive in tripschedule.adoc - include::/Users/goorm/Desktop/moheng/backend/build/generated-snippets/planner/schedule/trip/delete/request-headers.adoc[]</p>
-</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">엑세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect4">
 <h5 id="_request_body_64">Request Body</h5>
-<div class="paragraph">
-<p>Unresolved directive in tripschedule.adoc - include::/Users/goorm/Desktop/moheng/backend/build/generated-snippets/planner/schedule/trip/delete/request-body.adoc[]</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json"></code></pre>
+</div>
 </div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_http_response_70">HTTP Response</h4>
-<div class="paragraph">
-<p>Unresolved directive in tripschedule.adoc - include::/Users/goorm/Desktop/moheng/backend/build/generated-snippets/planner/schedule/trip/delete/http-response.adoc[]</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 66
+
+{
+  "message" : "존재하지 않는 일정 여행지입니다."
+}</code></pre>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_response_body_64">Response Body</h5>
-<div class="paragraph">
-<p>Unresolved directive in tripschedule.adoc - include::/Users/goorm/Desktop/moheng/backend/build/generated-snippets/planner/schedule/trip/delete/response-body.adoc[]</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "message" : "존재하지 않는 일정 여행지입니다."
+}</code></pre>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## 관련 IssueNumber

> #376 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- asciidoctor 테스크의 의존성을 build 테스크에 의존하도록 설정하여, API 명세가 정상 최신화되도록 설정합니다.