### PR TITLE
 #364 fix: 도커네트워크의 이름을 명시적으로 지정해주었습니다.

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -12,6 +12,8 @@ services:
     restart: always
     volumes:
       - ./nginx/srcs/:/etc/nginx/srcs
+      - ./nginx/tools/develop.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/nginx.conf/:/etc/nginx/nginx.conf
 
   backend:
     container_name: back
@@ -79,4 +81,5 @@ volumes:
 
 networks:
   moheng-network:
+    name: moheng-network
     driver: bridge

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -36,6 +36,7 @@ services:
 
 networks:
   moheng-network:
+    name: moheng-network
     driver: bridge
 #todo
 # nginx 로깅레벨 설정

--- a/nginx/Dockerfile.local
+++ b/nginx/Dockerfile.local
@@ -8,10 +8,6 @@ RUN apt-get update && \
     apt-get install -y certbot python3-certbot-nginx && \
     rm /etc/nginx/conf.d/default.conf
 
-# Nginx 설정 파일 복사
-COPY nginx.conf /etc/nginx/
-COPY tools/develop.conf /etc/nginx/conf.d/
-
 # Nginx가 사용하는 디렉터리 생성 및 권한 설정
 RUN mkdir -p /var/cache/nginx/client_temp /var/log/nginx && \
     chown -R appuser:appgroup \ 

--- a/nginx/tools/develop.conf
+++ b/nginx/tools/develop.conf
@@ -7,7 +7,7 @@ upstream backend {
 }
 
 upstream front {
-    server frontend:5173;
+    server frontend:3000;
 }
 
 server {
@@ -25,23 +25,23 @@ server {
         proxy_pass http://front;
     }
 
-    location ^~ /api/video {
-        # CORS policy
-        add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
+    # location ^~ /api/video {
+    #     # CORS policy
+    #     add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+    #     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    #     add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
 
-        # Preflight 요청 처리 (OPTIONS 메서드)
-        if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
-            return 204; # No Content 응답
-        }
+    #     # Preflight 요청 처리 (OPTIONS 메서드)
+    #     if ($request_method = 'OPTIONS') {
+    #         add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+    #         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    #         add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization';
+    #         return 204; # No Content 응답
+    #     }
 
-        alias /etc/nginx/srcs/; # 파일이 있는 디렉토리 경로
-        try_files $uri =404;    # 파일이 없으면 404 오류 반환
-    }
+    #     alias /etc/nginx/srcs/; # 파일이 있는 디렉토리 경로
+    #     try_files $uri =404;    # 파일이 없으면 404 오류 반환
+    # }
 
     location ~* ^/(api|docs)/ {
         proxy_set_header Host $http_host;


### PR DESCRIPTION
## 관련 IssueNumber

> #364 

<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [x] 💯 빌드와 테스트는 잘 통과했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 도커 네트워크의 경우 이름을 지어주지 않으면 디렉토리를 접두사로 붙여 사용하게 됩니다. 따라서 각기 다른 디렉토리에 있는 다른 두개의 도커파일을 동일한 네트워크에서 동작하게 하려면 이름을 명시적으로 지정해주어야합니다.
- nginx의 설정파일을 볼륨 마운트하는것으로 변경하였습니다. 
- nginx의 잘못된 포트번호 (5173 => 3000)로 수정했습니다.