### PR TITLE
[feat] 상세 여행지 조회에서 발생하는 동시성 이슈를 비관적 락으로 해결 

### DIFF
--- a/backend/src/main/java/moheng/recommendtrip/domain/tripfilterstrategy/TripLiveInformationFilterStrategy.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/tripfilterstrategy/TripLiveInformationFilterStrategy.java
@@ -49,9 +49,14 @@ public class TripLiveInformationFilterStrategy implements TripFilterStrategy {
         while (filteredSimilarTrips.size() < SIMILAR_TRIPS_COUNT) {
             final FindSimilarTripWithContentIdResponses similarTripWithContentIdResponses = externalSimilarTripModelClient.findSimilarTrips(trip.getContentId(), page);
             final List<Trip> filteredTripsByLiveInformation = findFilteredTripsByLiveInformation(trip, similarTripWithContentIdResponses.getContentIds());
-            filteredSimilarTrips.addAll(filteredTripsByLiveInformation);
+            filteredSimilarTrips.addAll(
+                    filteredTripsByLiveInformation
+                            .stream()
+                            .filter(similarTrip -> !similarTrip.getId().equals(trip.getId()))
+                            .collect(Collectors.toList()));
             page++;
         }
+
         if (filteredSimilarTrips.size() > SIMILAR_TRIPS_COUNT) {
             return filteredSimilarTrips.subList(0, SIMILAR_TRIPS_COUNT);
         }

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -1,5 +1,6 @@
 package moheng.trip.application;
 
+import jakarta.persistence.LockTimeoutException;
 import moheng.keyword.domain.TripKeyword;
 import moheng.keyword.domain.repository.TripKeywordRepository;
 import moheng.member.domain.Member;
@@ -17,6 +18,7 @@ import moheng.trip.domain.repository.MemberTripRepository;
 import moheng.trip.domain.repository.TripRepository;
 import moheng.trip.dto.*;
 import moheng.trip.exception.NoExistTripException;
+import org.hibernate.PessimisticLockException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +61,7 @@ public class TripService {
         final List<Trip> filteredSimilarTrips = tripFilterStrategy.execute(new LiveInformationFilterInfo(tripId));
         try {
             trip.incrementVisitedCount();
-        } catch (Exception e) {
+        } catch (final PessimisticLockException | LockTimeoutException e) {
             return new FindTripWithSimilarTripsResponse(trip, findKeywordsByTrip(trip), findTripsWithKeywords(filteredSimilarTrips));
         }
         saveRecommendTripByClickedLogs(memberId, trip);

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -60,9 +60,13 @@ public class TripService {
                 .orElseThrow(NoExistTripException::new);
         final TripFilterStrategy tripFilterStrategy = tripFilterStrategyProvider.findTripsByFilterStrategy(LIVE_INFO_STRATEGY);
         final List<Trip> filteredSimilarTrips = tripFilterStrategy.execute(new LiveInformationFilterInfo(tripId));
+        return findTripsWithIncreaseVisitedCount(trip, memberId, filteredSimilarTrips);
+    }
+
+    private FindTripWithSimilarTripsResponse findTripsWithIncreaseVisitedCount(final Trip trip, final long memberId, final List<Trip> filteredSimilarTrips) {
         try {
             trip.incrementVisitedCount();
-        } catch (final PessimisticLockingFailureException | LockTimeoutException e) {
+        } catch (final PessimisticLockingFailureException e) {
             return new FindTripWithSimilarTripsResponse(trip, findKeywordsByTrip(trip), findTripsWithKeywords(filteredSimilarTrips));
         }
         saveRecommendTripByClickedLogs(memberId, trip);

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -19,6 +19,7 @@ import moheng.trip.domain.repository.TripRepository;
 import moheng.trip.dto.*;
 import moheng.trip.exception.NoExistTripException;
 import org.hibernate.PessimisticLockException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,7 +62,7 @@ public class TripService {
         final List<Trip> filteredSimilarTrips = tripFilterStrategy.execute(new LiveInformationFilterInfo(tripId));
         try {
             trip.incrementVisitedCount();
-        } catch (final PessimisticLockException | LockTimeoutException e) {
+        } catch (final PessimisticLockingFailureException | LockTimeoutException e) {
             return new FindTripWithSimilarTripsResponse(trip, findKeywordsByTrip(trip), findTripsWithKeywords(filteredSimilarTrips));
         }
         saveRecommendTripByClickedLogs(memberId, trip);

--- a/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
+++ b/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 public interface TripRepository extends JpaRepository<Trip, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints( {@QueryHint(name = "javax.persistence.lock.timeout", value = "3000")})
-    Optional<Trip> findByIdForUpdate(final Long id);
+    @Query("SELECT t FROM Trip t WHERE t.id IN :tripId")
+    Optional<Trip> findByIdForUpdate(final Long tripId);
 
     Optional<Trip> findByContentId(final Long contentId);
 

--- a/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
+++ b/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
@@ -1,8 +1,10 @@
 package moheng.trip.domain.repository;
 
+import jakarta.persistence.LockModeType;
 import moheng.trip.domain.Trip;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,6 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Trip> findByIdForUpdate(final Long id);
+
     Optional<Trip> findByContentId(final Long contentId);
 
     List<Trip> findTop30ByOrderByVisitedCountDesc();

--- a/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
+++ b/backend/src/main/java/moheng/trip/domain/repository/TripRepository.java
@@ -1,11 +1,9 @@
 package moheng.trip.domain.repository;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import moheng.trip.domain.Trip;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -13,6 +11,7 @@ import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints( {@QueryHint(name = "javax.persistence.lock.timeout", value = "3000")})
     Optional<Trip> findByIdForUpdate(final Long id);
 
     Optional<Trip> findByContentId(final Long contentId);

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -931,7 +931,6 @@ public class TripServiceTest extends ServiceTestConfig {
 
         // then
         Trip updatedTrip = tripRepository.findById(currentTrip.getId()).orElseThrow();
-        System.out.println(updatedTrip.getVisitedCount());
         assertThat(updatedTrip.getVisitedCount()).isEqualTo(100);
     }
 }

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -933,4 +933,48 @@ public class TripServiceTest extends ServiceTestConfig {
         Trip updatedTrip = tripRepository.findById(currentTrip.getId()).orElseThrow();
         assertThat(updatedTrip.getVisitedCount()).isEqualTo(100);
     }
+
+    @Test
+    void qwe() throws InterruptedException {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
+
+        // when
+        for(int i=0; i<200; i++) {
+            new Thread(() -> {
+                tripService.findWithSimilarOtherTrips(1L, 1L);
+            }).start();
+        }
+        Thread.sleep(10000);
+    }
 }

--- a/backend/src/test/java/moheng/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/moheng/trip/application/TripServiceTest.java
@@ -319,7 +319,7 @@ public class TripServiceTest extends ServiceTestConfig {
 
         // when
         tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
-        long expected = tripService.findById(currentTrip.getId()).getId();
+        long expected = tripService.findById(currentTrip.getId()).getVisitedCount();
 
         // then
         assertThat(expected).isEqualTo(1L);
@@ -875,5 +875,63 @@ public class TripServiceTest extends ServiceTestConfig {
         // when, then
         assertThatThrownBy(() -> tripService.createMemberTrip(member.getId(), -1L))
                 .isInstanceOf(NoExistTripException.class);
+    }
+
+    @DisplayName("동시간대에 100명의 유저가 같은 여행지를 조회할 경우, 방문 수는 정확히 100으로 증가한다.")
+    @Test
+    void 동시간대에_100명의_유저가_같은_여행지를_조회할_경우_방문_수는_정확히_100으로_증가한다() throws InterruptedException {
+        // given
+        Member member = memberRepository.save(하온_기존());
+        Trip currentTrip = tripRepository.save(new Trip("여행지1", "서울", 1L, "설명1", "https://image.png", 0L));
+        Trip trip2 = tripRepository.save(new Trip("여행지2", "서울", 2L, "설명2", "https://image.png", 0L));
+        Trip trip3 = tripRepository.save(new Trip("여행지3", "서울", 3L, "설명3", "https://image.png", 0L));
+        Trip trip4 = tripRepository.save(new Trip("여행지4", "서울", 4L, "설명4", "https://image.png", 0L));
+        Trip trip5 = tripRepository.save(new Trip("여행지5", "서울", 5L, "설명5", "https://image.png", 0L));
+        Trip trip6 = tripRepository.save(new Trip("여행지6", "서울", 6L, "설명6", "https://image.png", 0L));
+        Trip trip7 = tripRepository.save(new Trip("여행지7", "서울", 7L, "설명7", "https://image.png", 0L));
+        Trip trip8 = tripRepository.save(new Trip("여행지8", "서울", 8L, "설명8", "https://image.png", 0L));
+        Trip trip9 = tripRepository.save(new Trip("여행지9", "서울", 9L, "설명9", "https://image.png", 0L));
+        Trip trip10 = tripRepository.save(new Trip("여행지10", "서울", 10L, "설명10", "https://image.png", 0L));
+        Trip trip11 = tripRepository.save(new Trip("여행지11", "서울", 11L, "설명10", "https://image.png", 0L));
+        recommendTripRepository.save(new RecommendTrip(currentTrip, member, 1L));
+        LiveInformation liveInformation = liveInformationRepository.save(new LiveInformation("생활정보1"));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, currentTrip));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip2)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip3));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip4)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip5));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip6)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip7));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip8)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip9));
+        tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip10)); tripLiveInformationRepository.save(new TripLiveInformation(liveInformation, trip11));
+
+        recommendTripRepository.save(new RecommendTrip(trip2, member, 1L));
+        recommendTripRepository.save(new RecommendTrip(trip3, member, 2L));
+        recommendTripRepository.save(new RecommendTrip(trip4, member, 3L));
+        recommendTripRepository.save(new RecommendTrip(trip5, member, 4L));
+        recommendTripRepository.save(new RecommendTrip(trip6, member, 5L));
+        recommendTripRepository.save(new RecommendTrip(trip7, member, 6L));
+        recommendTripRepository.save(new RecommendTrip(trip8, member, 7L));
+        recommendTripRepository.save(new RecommendTrip(trip9, member, 8L));
+        recommendTripRepository.save(new RecommendTrip(trip10, member, 9L));
+        recommendTripRepository.save(new RecommendTrip(trip11, member, 10L));
+
+        // when
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    tripService.findWithSimilarOtherTrips(currentTrip.getId(), member.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        // then
+        Trip updatedTrip = tripRepository.findById(currentTrip.getId()).orElseThrow();
+        System.out.println(updatedTrip.getVisitedCount());
+        assertThat(updatedTrip.getVisitedCount()).isEqualTo(100);
     }
 }


### PR DESCRIPTION
## 관련 IssueNumber

> #294 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 상세 여행지 조회시 방문수 카운팅 로직에서 발생하는 동시성 이슈를 비관적 락으로 해결했습니다. 