### PR TITLE
[feat] 여행지 조회시 접속자 수가 많아 발생하는 동시성 이슈에 대한 상세 예외처리

### DIFF
--- a/backend/src/main/java/moheng/global/error/ControllerAdvice.java
+++ b/backend/src/main/java/moheng/global/error/ControllerAdvice.java
@@ -56,7 +56,6 @@ public class ControllerAdvice {
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
-
     @ExceptionHandler(InvalidOAuthServiceException.class)
     public ResponseEntity<ExceptionResponse> handleOAuthException(final RuntimeException e) {
         logger.error(e.getMessage(), e);
@@ -133,6 +132,16 @@ public class ControllerAdvice {
         ExceptionResponse errorResponse = new ExceptionResponse(e.getMessage());
 
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(errorResponse);
+    }
+
+    @ExceptionHandler({
+            NotAbleToAccessTripByPessimisticLock.class
+    })
+    public ResponseEntity<ExceptionResponse> handleConcurrencyIssue(final RuntimeException e) {
+        logger.error(e.getMessage(), e);
+        ExceptionResponse errorResponse = new ExceptionResponse(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/backend/src/main/java/moheng/trip/application/TripService.java
+++ b/backend/src/main/java/moheng/trip/application/TripService.java
@@ -62,8 +62,10 @@ public class TripService {
                     .orElseThrow(NoExistTripException::new);
             final TripFilterStrategy tripFilterStrategy = tripFilterStrategyProvider.findTripsByFilterStrategy(LIVE_INFO_STRATEGY);
             final List<Trip> filteredSimilarTrips = tripFilterStrategy.execute(new LiveInformationFilterInfo(tripId));
+
             trip.incrementVisitedCount();
             saveRecommendTripByClickedLogs(memberId, trip);
+
             return new FindTripWithSimilarTripsResponse(trip, findKeywordsByTrip(trip), findTripsWithKeywords(filteredSimilarTrips));
         } catch (PessimisticLockException e) {
             throw new NotAbleToAccessTripByPessimisticLock("접속자 수가 많아 여행지 조회가 불가능합니다. 잠시 후에 시도해주세요.");

--- a/backend/src/main/java/moheng/trip/exception/NotAbleToAccessTripByPessimisticLock.java
+++ b/backend/src/main/java/moheng/trip/exception/NotAbleToAccessTripByPessimisticLock.java
@@ -1,0 +1,7 @@
+package moheng.trip.exception;
+
+public class NotAbleToAccessTripByPessimisticLock extends RuntimeException {
+    public NotAbleToAccessTripByPessimisticLock(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 관련 IssueNumber

> #294 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 여행지 조회시 접속자 수가 많아 발생하는 동시성 이슈에 대한 상세 예외처리를 진행했습니다.
-  상태코드는 409 `Conflict` 로 처리했으며, 비관적 락에 대한 예외처리 클래스를 RuntimeException 으로 캐치합니다.