### PR TITLE
[feat] 로컬 캐시를 사용한 외부 API 요청 최적화 

### DIFF
--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -1,10 +1,23 @@
 package moheng.global.cache;
 
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
     public static final String EXTERNAL_SIMILAR_TRIP_CACHE = "SIMILAR_TRIP_CACHE";
+    private static final long LIFE_CYCLE = 60 * 60;
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        simpleCacheManager.setCaches(List.of(new ExternalSimilarTripCache(EXTERNAL_SIMILAR_TRIP_CACHE, LIFE_CYCLE)));
+        return simpleCacheManager;
+    }
 }

--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -5,12 +5,14 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.List;
 
 @Configuration
 @EnableCaching
+@EnableScheduling
 public class CacheConfig {
     public static final String EXTERNAL_SIMILAR_TRIP_CACHE = "SIMILAR_TRIP_CACHE";
     private static final long LIFE_CYCLE = 60 * 60 * 2;

--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -6,4 +6,5 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableCaching
 public class CacheConfig {
+    public static final String EXTERNAL_AI_CACHE = "aiCache";
 }

--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -6,5 +6,5 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableCaching
 public class CacheConfig {
-    public static final String EXTERNAL_AI_CACHE = "aiCache";
+    public static final String EXTERNAL_SIMILAR_TRIP_CACHE = "SIMILAR_TRIP_CACHE";
 }

--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -1,0 +1,9 @@
+package moheng.global.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/backend/src/main/java/moheng/global/cache/CacheConfig.java
+++ b/backend/src/main/java/moheng/global/cache/CacheConfig.java
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.List;
 
@@ -12,12 +13,18 @@ import java.util.List;
 @EnableCaching
 public class CacheConfig {
     public static final String EXTERNAL_SIMILAR_TRIP_CACHE = "SIMILAR_TRIP_CACHE";
-    private static final long LIFE_CYCLE = 60 * 60;
+    private static final long LIFE_CYCLE = 60 * 60 * 2;
 
     @Bean
     public CacheManager cacheManager() {
         SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
         simpleCacheManager.setCaches(List.of(new ExternalSimilarTripCache(EXTERNAL_SIMILAR_TRIP_CACHE, LIFE_CYCLE)));
         return simpleCacheManager;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    private void evict() {
+        ExternalSimilarTripCache externalSimilarTripCache = (ExternalSimilarTripCache)  cacheManager().getCache(EXTERNAL_SIMILAR_TRIP_CACHE);
+        externalSimilarTripCache.evictAllTrips();
     }
 }

--- a/backend/src/main/java/moheng/global/cache/ExternalSimilarTripCache.java
+++ b/backend/src/main/java/moheng/global/cache/ExternalSimilarTripCache.java
@@ -1,0 +1,43 @@
+package moheng.global.cache;
+
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ExternalSimilarTripCache extends ConcurrentMapCache {
+    private final Map<Object, LocalDateTime> tripCache = new ConcurrentHashMap<>();
+    private final long expiresDatePoint;
+
+    public ExternalSimilarTripCache(final String name, final long expiresDatePoint) {
+        super(name);
+        this.expiresDatePoint = expiresDatePoint;
+    }
+
+    @Override
+    protected Object lookup(final Object key) {
+        LocalDateTime expiredDate = tripCache.get(key);
+        if(Objects.isNull(expiredDate) || isCacheValid(expiredDate)) {
+            return super.lookup(key);
+        }
+
+        tripCache.remove(key);
+        super.evict(key);
+        return null;
+    }
+
+    @Override
+    public void put(final Object key, final Object value) {
+        LocalDateTime expiredAt = LocalDateTime.now().plusSeconds(expiresDatePoint);
+        tripCache.put(key, expiredAt);
+
+        super.put(key, value);
+    }
+
+    private boolean isCacheValid(final LocalDateTime expiredDate) {
+        return LocalDateTime.now().isBefore(expiredDate);
+    }
+}

--- a/backend/src/main/java/moheng/recommendtrip/domain/tripfilterstrategy/TripLiveInformationFilterStrategy.java
+++ b/backend/src/main/java/moheng/recommendtrip/domain/tripfilterstrategy/TripLiveInformationFilterStrategy.java
@@ -63,6 +63,7 @@ public class TripLiveInformationFilterStrategy implements TripFilterStrategy {
         return filteredSimilarTrips;
     }
 
+
     private List<Trip> findFilteredTripsByLiveInformation(final Trip currentTrip, final List<Long> contentIds) {
         final List<LiveInformation> liveInformations = liveInformationRepository.findLiveInformationByTrip(currentTrip);
         final List<Trip> filteredTrips = new ArrayList<>();

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
@@ -6,6 +6,7 @@ import moheng.trip.domain.model.ExternalRecommendModelClient;
 import moheng.trip.dto.RecommendTripsByVisitedLogsRequest;
 import moheng.trip.dto.RecommendTripsByVisitedLogsResponse;
 import moheng.trip.dto.RecommendTripsRequest;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ public class ExternalAiRecommendModelClient implements ExternalRecommendModelCli
     public ExternalAiRecommendModelClient(final RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
+
 
     @Override
     public RecommendTripsByVisitedLogsResponse recommendTripsByVisitedLogs(final RecommendTripsByVisitedLogsRequest request) {

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiRecommendModelClient.java
@@ -1,5 +1,6 @@
 package moheng.trip.infrastructure;
 
+import moheng.global.cache.CacheConfig;
 import moheng.keyword.exception.InvalidAIServerException;
 import moheng.recommendtrip.dto.PreferredLocationRequest;
 import moheng.trip.domain.model.ExternalRecommendModelClient;
@@ -24,7 +25,6 @@ public class ExternalAiRecommendModelClient implements ExternalRecommendModelCli
     public ExternalAiRecommendModelClient(final RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
-
 
     @Override
     public RecommendTripsByVisitedLogsResponse recommendTripsByVisitedLogs(final RecommendTripsByVisitedLogsRequest request) {

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
@@ -1,9 +1,11 @@
 package moheng.trip.infrastructure;
 
+import moheng.global.cache.CacheConfig;
 import moheng.keyword.exception.InvalidAIServerException;
 import moheng.trip.domain.model.ExternalSimilarTripModelClient;
 import moheng.trip.dto.FindSimilarTripWithContentIdResponses;
 import moheng.trip.dto.SimilarTripRequests;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -20,6 +22,7 @@ public class ExternalAiSimilarTripModelClient implements ExternalSimilarTripMode
         this.restTemplate = restTemplate;
     }
 
+    @Cacheable(value = CacheConfig.EXTERNAL_AI_CACHE, key = "#contentId+#page")
     @Override
     public FindSimilarTripWithContentIdResponses findSimilarTrips(final long contentId, final long page) {
         return requestSimilarTrips(new SimilarTripRequests(contentId, page));

--- a/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
+++ b/backend/src/main/java/moheng/trip/infrastructure/ExternalAiSimilarTripModelClient.java
@@ -22,7 +22,7 @@ public class ExternalAiSimilarTripModelClient implements ExternalSimilarTripMode
         this.restTemplate = restTemplate;
     }
 
-    @Cacheable(value = CacheConfig.EXTERNAL_AI_CACHE, key = "#contentId+#page")
+    @Cacheable(value = CacheConfig.EXTERNAL_SIMILAR_TRIP_CACHE, key = "#contentId+#page")
     @Override
     public FindSimilarTripWithContentIdResponses findSimilarTrips(final long contentId, final long page) {
         return requestSimilarTrips(new SimilarTripRequests(contentId, page));


### PR DESCRIPTION
## 관련 IssueNumber

> #425 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
- [X] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

### 캐싱 전략으로 성능 최적화

여행지 상세 페이지에서 비슷한 여행지를 조회하는데 성능이 꽤 좋지 않았습니다. 로컬에서 테스트한 결과 보통의 경우 약 `450ms` 정도의 결과가 도출되며, 간혹 최악의 경우엔 `600ms` 까지 소요되는 듯 합니다. 로컬이 아닌 개발 서버에서 테스트할 경우 더 오랜 시간이 걸리는 듯 합니다. 저희 모행 서비스를 이용하는데 여행지 조회시 걸리는 시간이 꽤 오래걸려서, 개발자인 저희 조차 답답함과 불편함이 느껴졌습니다. 외부 API 를 호출하는 방식 이기 떄문에, 데이터베이스 인덱스 적용도 불가능한 상태라, 성능을 어떻게 최적화할지 고민이 많았습니다.

![image](https://github.com/user-attachments/assets/43d1240b-7192-47b4-a034-dc457c57b4ea)

이에 대한 성능을 최적화 하고자 했습니다. `로컬 캐시` 를 이용하여, 캐싱된 내용을 읽어오도록 성능을 최적화했습니다. 그 결과는 로컬 테스트 기준 약 `20ms` 정도의 성능으로 개선되었네요. 이후 개발 서버에서도 성능이 얼마나 나오는지 테스트 해보고자 합니다.

### 캐싱에 대한 TTL 및 스캐쥴링 지원 

![image](https://github.com/user-attachments/assets/a786ebf1-2753-4799-863b-26f365071cd6)

스프링에서 기본적으로 제공하는 캐시 구현체는 `ConcurrentMapCache` 입니다. 다만, TTL 이 존재하지 않아 외부 캐시 저장소인 `Redis` 나 `Encache` 를 구현할 수도 있었지만, 충분히 로컬 캐시를 커스터마이징하여 TTL 기능을 만들 수 있겠다고 생각이 들었어요.

실제로  `ConcurrentMapCache` 를 상속한 캐시 구현체를 직접 만들었습니다. TTL 기능을 지원하여 2시간마다 만료된 캐시를 제거합니다. 또한 매일 자정마다 스캐쥴링을 통해 사용되지 않는 캐시 데이터를 지우도록 구현했습니다.
