### PR TITLE
[fix] Argument Resolver 를 사용시 DB 레플리케이션 환경에서 DataSource 라우팅이 안되는 문제 해결 

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -49,7 +49,7 @@ logging:
 oauth:
   kakao:
     authorize_uri: https://kauth.kakao.com/oauth/authorize
-    redirect_uri: http://localhost:3000/callback/kakao
+    redirect_uri: https://moheng.life/callback/kakao
     client_secret: 3ZPJ93VC9MCuCXmPCDzrGmum2M3A7tif
     token_uri: https://kauth.kakao.com/oauth/token
     user_uri: https://kapi.kakao.com/v2/user/me

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -13,20 +13,20 @@ spring:
       maximum-pool-size: 3
       connection-timeout: 3000
     source:
-      username: ${SOURCE_USERNAME}
-      password: ${SOURCE_PASSWORD}
+      username: haon
+      password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: ${SOURCE_DATASOURCE_URL}
+      jdbc-url: jdbc:mysql://13.211.42.88:3306/replication
     replica1:
-      username: ${REPLICA_USERNAME1}
-      password: ${REPLICA_PASSWORD1}
+      username: haon
+      password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: ${REPLICA_DATASOURCE_URL1}
+      jdbc-url: jdbc:mysql://3.104.111.67:3306/replication
     replica2:
-      username: ${REPLICA_USERNAME2}
-      password: ${REPLICA_PASSWORD2}
+      username: haon
+      password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: ${REPLICA_DATASOURCE_URL2}
+      jdbc-url: jdbc:mysql://3.104.111.67:3306/replication
   lifecycle:
     timeout-per-shutdown-phase: 10s
   jpa:
@@ -37,6 +37,7 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+    open-in-view: false
 logging:
   level:
     org:
@@ -48,7 +49,7 @@ logging:
 oauth:
   kakao:
     authorize_uri: https://kauth.kakao.com/oauth/authorize
-    redirect_uri: https://moheng.life/callback/kakao
+    redirect_uri: http://localhost:3000/callback/kakao
     client_secret: 3ZPJ93VC9MCuCXmPCDzrGmum2M3A7tif
     token_uri: https://kauth.kakao.com/oauth/token
     user_uri: https://kapi.kakao.com/v2/user/me

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -16,17 +16,17 @@ spring:
       username: haon
       password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://13.211.42.88:3306/replication
+      jdbc-url: ${SOURCE_DATASOURCE_URL}
     replica1:
       username: haon
       password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://3.104.111.67:3306/replication
+      jdbc-url: ${REPLICA_DATASOURCE_URL1}
     replica2:
       username: haon
       password: password
       driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: jdbc:mysql://3.104.111.67:3306/replication
+      jdbc-url: ${REPLICA_DATASOURCE_URL2}
   lifecycle:
     timeout-per-shutdown-phase: 10s
   jpa:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -13,18 +13,18 @@ spring:
       maximum-pool-size: 3
       connection-timeout: 3000
     source:
-      username: haon
-      password: password
+      username: ${SOURCE_USERNAME}
+      password: ${SOURCE_PASSWORD}
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbc-url: ${SOURCE_DATASOURCE_URL}
     replica1:
-      username: haon
-      password: password
+      username: ${REPLICA_USERNAME1}
+      password: ${REPLICA_PASSWORD1}
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbc-url: ${REPLICA_DATASOURCE_URL1}
     replica2:
-      username: haon
-      password: password
+      username: ${REPLICA_USERNAME2}
+      password: ${REPLICA_PASSWORD2}
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbc-url: ${REPLICA_DATASOURCE_URL2}
   lifecycle:


### PR DESCRIPTION
## 관련 IssueNumber

> #440 

<details>
<summary> PR 체크리스트</summary>
  
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] 소셜 로그인 구현
- [X] 💯 빌드와 테스트는 잘 통과했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?
</details>

## 변경사항

- JPA OSIV 를 비활성화하여 DB 레플리케이션 환경에서 라우팅이 정상 동작하지 않는 문제를 해결했습니다.
- OSIV를 비활성화하면 영속성 컨텍스트의 생존 범위는 트랜잭션 시작부터 종료까지로 좁혀집니다. 즉, 트랜잭션이 시작될 때 영속성 컨텍스트가 실행되고, 트랜잭션이 끝날 때 까지 유지됩니다. 즉, 영속성 컨텍스트가 여러번 생성되고, 커넥션도 여러번 획득하고, 따라서 DataSource 도 개별 트랜잭션마다 선택됩니다. 즉, DataSource 의 분기가 정상적으로 이루어집니다.
